### PR TITLE
Fix invalid option "Get 2 Power Tokens" when already one muster point was used

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
@@ -97,7 +97,8 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                                 </Col>
                                 <Col>
                                     {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER &&
-                                         this.selectedRegion != null && (
+                                         this.selectedRegion != null && 
+                                         this.props.gameState.getPointsLeft(this.selectedRegion, this.musterings) == 2 && (
                                             <Button onClick={() => this.submitForPT()}>Get 2 power tokens</Button>
                                         )
                                     }


### PR DESCRIPTION
Fix issue #102 