### PR TITLE
Fix exceeded unit count when mustering

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
@@ -278,7 +278,15 @@ export default class PlayerMusteringGameState extends GameState<ParentGameState>
                         ? this.getPotentialUnitForUpgrading(musterings, recruitmentRegion, rule.from) != null
                         : true)
                     // Check that the mustering doesn't hit unit limits
-                    .filter(rule => this.game.getAvailableUnitsOfType(this.house, rule.to) > 0)
+                    .filter(rule => {
+                        const flattenedMusterings = _.flatMap(musterings.values);
+                        // Take into accounts units that have already been mustered
+                        const alreadyMusteredUnits = flattenedMusterings.filter(m => m.to == rule.to).length;
+                        // Musterings might have freed units that can be used to realize musterings
+                        const freedUnits = flattenedMusterings.filter(m => m.from && m.from.type == rule.to).length;
+                      
+                        return this.game.getAvailableUnitsOfType(this.house, rule.to) + freedUnits - alreadyMusteredUnits;
+                      })
                     // Check that the mustering respects supply
                     // An upgrade always respect supply (one unit is removed, one unit is added)
                     // A mustering may break supply


### PR DESCRIPTION
Fixes #141 

Is this just evaluated on client side and can be undermined? Do we need a check on server side?