### PR TITLE
Prevent retreat to enemy controlled regions by power tokens

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/World.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/World.ts
@@ -127,7 +127,7 @@ export default class World {
             // by the retreater
             .filter(r => !(r.type == port && this.getAdjacentLandOfPort(r).getController() != house))
             // Remove regions with enemy units
-            .filter(r => !(r.getController() != house && r.units.size > 0))
+            .filter(r => !(r.getController() != null && r.getController() != house))
             // Remove regions with neutral forces
             .filter(r => !(r.garrison > 0 && r.getController() == null));
     }


### PR DESCRIPTION
@gereon77 I realized that an army could retreat to a region that is only controlled by a enemy power token. This PR should fix it.