### PR TITLE
Allow delaying starred consolidate power orders

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -426,14 +426,14 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                     </p>
                 </>;
 
-            case "starred-consolidate-power-for-power-tokens":
+            case "consolidate-power-order-resolved":
                 house = this.game.houses.get(data.house);
                 region = this.world.regions.get(data.region);
                 const countPowerToken = data.powerTokenCount;
 
                 return <>
-                    <strong>{house.name}</strong> resolved a Starred Consolidate Power Order token
-                    in <strong>{region.name}</strong> to gain <strong>{countPowerToken}</strong> Power token{countPowerToken > 0 && "s"}.
+                    <strong>{house.name}</strong> resolved a {data.starred && "Starred "}Consolidate Power Order
+                    in <strong>{region.name}</strong> to gain <strong>{countPowerToken}</strong> Power token{countPowerToken > 1 && "s"}.
                 </>;
 
             case "armies-reconciled":

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -10,7 +10,7 @@ export type GameLogData = TurnBegin | SupportDeclared | Attack | MarchResolved
     | PutToTheSwordChoice | AThroneOfBladesChoice | WinterIsComing | WesterosPhaseBegan
     | CombatHouseCardChosen | CombatValyrianSwordUsed | ClashOfKingsBiddingDone | ClashOfKingsFinalOrdering
     | ActionPhaseBegan | PlanningPhaseBegan | WildlingStrengthTriggerWildlingsAttack | MarchOrderRemoved
-    | StarredConsolidatePowerForPowerTokens | ArmiesReconciled | EnemyPortTaken | ShipsDestroyedByEmptyCastle
+    | ConsolidatePowerOrderResolved | ArmiesReconciled | EnemyPortTaken | ShipsDestroyedByEmptyCastle
     | TyrionLannisterHouseCardReplaced | TyrionLannisterChoiceMade
     | ArianneMartellPreventMovement | LorasTyrellAttackOrderMoved | TywinLannisterPowerTokensGained
     | RooseBoltonHouseCardsReturned | QueenOfThornsOrderRemoved | QueenOfThornsNoOrderAvailable
@@ -208,10 +208,11 @@ interface MarchOrderRemoved {
     region: string;
 }
 
-interface StarredConsolidatePowerForPowerTokens {
-    type: "starred-consolidate-power-for-power-tokens";
+interface ConsolidatePowerOrderResolved {
+    type: "consolidate-power-order-resolved";
     house: string;
     region: string;
+    starred: boolean;
     powerTokenCount: number;
 }
 


### PR DESCRIPTION
Implements #134 

This is my approach how this could be solved. I tried to do as few changes as possible but while testing I always found a glitch that forced me to extend the current implementation a bit. For example the "canSubmit()" check. When I don't modify it you can submit on non castle areas which does nothing. As always I am open for feedback and will adjust all necessary requested changes. Due to lack of time I didn't comment always why I changed the implementation but don't hesitate to ask if something is unclear. I guess I will be able to remember everything and can explain or comment it more detailed then.