### PR TITLE
Show bid result for each house while resolving ties

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/ResolveTiesComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveTiesComponent.tsx
@@ -29,7 +29,7 @@ export default class ResolveTiesComponent extends Component<GameStateComponentPr
         return (
             <>
                 <Col xs={12}>
-                    The holder of the iron throne can resolve the ties of the bidding.
+                    The holder of the Iron Throne can resolve the ties of the bidding.
                 </Col>
                 {this.props.gameClient.doesControlHouse(this.props.gameState.decider) ? (
                     <>
@@ -42,6 +42,7 @@ export default class ResolveTiesComponent extends Component<GameStateComponentPr
                                                  style={{backgroundImage: `url(${houseInfluenceImages.get(h.id)})`}}>
                                             </div>
                                         </div>
+                                        <div className="text-center" style={{fontSize: "18px", marginBottom: "5px"}}>{this.props.gameState.getBidOfHouse(h)}</div>
                                         <div className="btn-group btn-group-xs">
                                             <button
                                                 className="btn btn-primary"

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/clash-of-kings-game-state/resolve-ties-game-state/ResolveTiesGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/clash-of-kings-game-state/resolve-ties-game-state/ResolveTiesGameState.ts
@@ -113,6 +113,15 @@ export default class ResolveTiesGameState extends GameState<ClashOfKingsGameStat
             .filter(({trackerPlace, houses}) => houses.length > 1);
     }
 
+    getBidOfHouse(house: House): number {
+        const index = this.bidResults.findIndex(([bid, houses], i) => houses.includes(house));
+        if(index > -1) {
+            return this.bidResults[index][0];
+        }
+
+        return -1;
+    }
+
     serializeToClient(admin: boolean, player: Player | null): SerializedResolveTiesGameState {
         return {
             type: "resolve-ties",


### PR DESCRIPTION
Fixes #159 

Preview:

![image](https://user-images.githubusercontent.com/22304202/74219127-3a095f00-4cac-11ea-93e8-9c137df1c69b.png)

Game log for all bids is already sent correctly after all bids are received but this avoids scrolling to the game log end.

As always I am open for a better place of the bid result. I decided to place it at the influence token as it looks weird between the arrows but of course I could provide that also. In fact, feel free to take this PR and adapt the design as you want it.