### PR TITLE
Fix crow killers

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -769,7 +769,9 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 units = data.units.map(([rid, utids]) => [this.world.regions.get(rid), utids.map(utid => unitTypes.get(utid))]);
 
                 return <>
-                    <strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Knights in <strong>{region.name}</strong></>), ", ")} by Footmen.
+                    {units.length > 0 
+                    ? (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Knights in <strong>{region.name}</strong></>), ", ")} by Footmen.</>)
+                    : (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> had no Knights to replace by Footmen.</>)}
                 </>;
 
             case "crow-killers-footman-upgraded":
@@ -777,7 +779,9 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 units = data.units.map(([rid, utids]) => [this.world.regions.get(rid), utids.map(utid => unitTypes.get(utid))]);
 
                 return <>
-                    <strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Footmen in <strong>{region.name}</strong></>), ", ")} by Knights.
+                    {units.length > 0 
+                    ? (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Footmen in <strong>{region.name}</strong></>), ", ")} by Knights.</>) 
+                    : (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> was not able to replace any Footman by Knights.</>)}
                 </>;
 
             case "skinchanger-scout-nights-watch-victory":

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
@@ -35,6 +35,12 @@ export default class CrowKillersNightsWatchVictoryGameState extends GameState<Wi
         count = Math.min(count, availableKnights);
 
         if (count == 0) {
+            this.ingame.log({
+                type: "crow-killers-footman-upgraded",
+                house: house.id,
+                units: []
+            });
+
             this.parentGameState.onWildlingCardExecuteEnd();
             return;
         }

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
@@ -41,8 +41,8 @@ export default class CrowKillersNightsWatchVictoryGameState extends GameState<Wi
 
         this.setChildGameState(new SelectUnitsGameState(this)).firstStart(
             this.parentGameState.highestBidder,
-            this.getAllFootmen(),
-            2
+            availableFootmen,
+            count
         );
     }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
@@ -42,6 +42,12 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
 
             this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, selectableKnights, count);
         } else {
+            this.ingame.log({
+                type: "crow-killers-knights-replaced",
+                house: house.id,
+                units: []
+            });
+
             this.proceedNextHouse(house);
         }
     }

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
@@ -20,6 +20,7 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
         // Replace all of his knights by footmen
         const knightsToTransform = this.game.world
             .getControlledRegions(house)
+            .filter(r => r.units.values.some(u => u.type == knight))
             .map(r => [r, r.units.values.filter(u => u.type == knight)] as [Region, Unit[]]);
 
         knightsToTransform.forEach(([region, knights]) => this.transformIntoFootman(house, region, knights));


### PR DESCRIPTION
I started this PR as I realized during CP test that the log entry for crow killers wildlings victory add lines for every controlled region, even sea areas which never contain knights. When fixing that I realized that the log is weird when there was nothing to downgrade. So I added logs for that scenario also. Then I checked the nightwatch victory and found a possible bug in case you just have 1 footman or 1 available knight.