### PR TITLE
Add wildling strength to wildling bidding results

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -177,8 +177,8 @@ export default class GameLogListComponent extends Component<GameLogListComponent
 
                 return (
                     <>
-                        Wildling bidding results:
-                        <table>
+                        Wildling bidding results for wildling strength <strong>{data.wildlingStrength}</strong>:
+                        <table cellPadding="5">
                             {results.map(([bid, houses]) => houses.map(h => (
                                 <tr key={h.id}>
                                     <td>{h.name}</td>
@@ -189,7 +189,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                         {data.nightsWatchVictory ? (
                             <>The <strong>Night&apos;s Watch</strong> won!</>
                         ) : (
-                            <>The <strong>Wildling</strong> won!</>
+                            <>The <strong>Wildlings</strong> won!</>
                         )}
                     </>
                 );

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -95,6 +95,7 @@ interface WildlingCardRevealed {
 
 interface WildlingBidding {
     type: "wildling-bidding";
+    wildlingStrength: number;
     results: [number, string[]][];
     nightsWatchVictory: boolean;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
@@ -133,6 +133,7 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
 
         this.westerosGameState.ingame.log({
             type: "wildling-bidding",
+            wildlingStrength: this.westerosGameState.game.wildlingStrength,
             results: results.map(([bid, houses]) => [bid, houses.map(h => h.id)]),
             nightsWatchVictory: this.nightsWatchWon
         });


### PR DESCRIPTION
In case of westeros card wildlings attack you don't see in the game log what the actual wildling strength value was. This PR fixes that, well knowing that in case of a wildling attack triggered by wildling strength 12 the information will also be shown.