### PR TITLE
Improve battle overview and gamelog

### DIFF
--- a/agot-bg-game-server/src/client/CombatInfoComponent.tsx
+++ b/agot-bg-game-server/src/client/CombatInfoComponent.tsx
@@ -21,6 +21,7 @@ interface HouseCombatData {
 
 interface CombatInfoComponentProps {
     housesCombatData: HouseCombatData[];
+    showTitle: boolean;
 }
 
 @observer
@@ -38,6 +39,11 @@ export default class CombatInfoComponent extends Component<CombatInfoComponentPr
     render(): ReactNode {
         return (
             <>
+                {this.props.showTitle && (
+                    <div style={{display: 'flex', justifyContent: 'center'}}>
+                        <h5>Battle for <strong>{this.defender.region.name}</strong></h5>
+                    </div>
+                )}
                 <div style={{display: "grid", gridGap: "5px", gridTemplateColumns: "auto 1fr auto 1fr auto", justifyItems: "center", alignItems: "center"}} className="text-center">
                     <div style={{gridRow: "1", gridColumn: "1 / span 2"}}>
                         <strong>{this.attacker.house.name}</strong><br/>

--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -154,7 +154,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 return (
                     <>
                         <p>Combat result</p>
-                        <CombatInfoComponent housesCombatData={houseCombatDatas}/>
+                        <CombatInfoComponent housesCombatData={houseCombatDatas} showTitle={false}/>
                         <p><strong>{winner.name}</strong> won the fight!</p>
                     </>
                 );

--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -374,19 +374,9 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 return <><strong>{house.name}</strong> used the <strong>Valyrian Sword</strong>.</>;
 
             case "combat-house-card-chosen":
-                const houseCards = data.houseCards.map(([hid, hcid]) => {
-                    const house = this.game.houses.get(hid);
-                    return [house, house.houseCards.get(hcid)];
-                });
-
-                return <>
-                    <p>House cards were chosen:</p>
-                    <ul>
-                        {houseCards.map(([h, hc]) => (
-                            <li key={h.id}><strong>{h.name}</strong> chose <strong>{hc.name}</strong></li>
-                        ))}
-                    </ul>
-                </>;
+                // Obsolete as GameInfoComponent shows this now
+                // Kept to be backwards compatible
+                return <></>;
 
             case "clash-of-kings-final-ordering":
                 const finalOrder = data.finalOrder.map(hid => this.game.houses.get(hid));

--- a/agot-bg-game-server/src/client/game-state-panel/CombatComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/CombatComponent.tsx
@@ -15,7 +15,6 @@ import UseValyrianSteelBladeComponent from "./UseValyrianSteelBladeComponent";
 import House from "../../common/ingame-game-state/game-data-structure/House";
 import GameStateComponentProps from "./GameStateComponentProps";
 import renderChildGameState from "../utils/renderChildGameState";
-import Table from "react-bootstrap/Table";
 import PostCombatGameState
     from "../../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState";
 import PostCombatComponent from "./PostCombatComponent";
@@ -74,7 +73,7 @@ export default class CombatComponent extends Component<GameStateComponentProps<C
                                     valyrianSteelBlade: this.combatGameState.getValyrianBladeBonus(this.defender),
                                     total: this.combatGameState.getTotalCombatStrength(this.defender),
                                 }
-                            ]}
+                            ]} showTitle={true}
                         />
                     )}
                 </Col>

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/choose-house-card-game-state/ChooseHouseCardGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/choose-house-card-game-state/ChooseHouseCardGameState.ts
@@ -63,20 +63,6 @@ export default class ChooseHouseCardGameState extends GameState<CombatGameState>
             if (this.houseCards.size == 2) {
                 this.houseCards.forEach((houseCard, house) => this.combatGameState.houseCombatDatas.get(house).houseCard = houseCard);
 
-                // "this.combatGameState.attackingHouseCombatData.houseCard" and
-                // "this.combatGameState.defendingHouseCombatData.houseCard" will always be non-null
-                // since they have just been set before, thus the two "ts-ignore". They could be later set to null
-                // because of Tyrion Lannister, for example.
-                this.ingameGameState.log({
-                    type: "combat-house-card-chosen",
-                    houseCards: [
-                        // @ts-ignore
-                        [this.combatGameState.attacker.id, this.combatGameState.attackingHouseCombatData.houseCard.id],
-                        // @ts-ignore
-                        [this.combatGameState.defender.id, this.combatGameState.defendingHouseCombatData.houseCard.id]
-                    ]
-                });
-
                 this.entireGame.broadcastToClients({
                     type: "change-combat-house-card",
                     // Same here, the houseCards will always be non-null

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -40,11 +40,6 @@ interface SupportDeclared {
     supported: string | null;
 }
 
-interface HouseCardChosen {
-    type: "house-card-chosen";
-    houseCards: [string, string][];
-}
-
 interface Attack {
     type: "attack";
     attacker: string;
@@ -169,6 +164,7 @@ interface WesterosPhaseBegan {
     type: "westeros-phase-began";
 }
 
+// This is obsolete but need to be kept for now to be backwards compatible
 interface CombatHouseCardChosen {
     type: "combat-house-card-chosen";
     houseCards: [string, string][];


### PR DESCRIPTION
Relates to #260 

Action panel:
![battle1](https://user-images.githubusercontent.com/22304202/75427269-801a2000-5946-11ea-9a09-f254cae0fab0.PNG)

GameLog:
![image](https://user-images.githubusercontent.com/22304202/75427296-8ad4b500-5946-11ea-87c0-2241235b1c22.png)
