### PR TITLE
All regions must have orders

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/PlanningComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlanningComponent.tsx
@@ -45,7 +45,8 @@ export default class PlanningComponent extends Component<GameStateComponentProps
                                 <Row className="justify-content-center">
                                     <Col xs="auto">
                                         <Button
-                                            disabled={this.props.gameState.isReady(this.props.gameClient.authenticatedPlayer)}
+                                            disabled={this.props.gameState.isReady(this.props.gameClient.authenticatedPlayer)
+                                                || !this.props.gameState.canReady(this.props.gameClient.authenticatedPlayer.house).status}
                                             onClick={() => this.onReadyClick()}
                                         >
                                             Ready
@@ -141,13 +142,6 @@ export default class PlanningComponent extends Component<GameStateComponentProps
     }
 
     onReadyClick(): void {
-        if (this.props.gameClient.authenticatedPlayer
-            && !this.props.gameState.areOrdersAssignedToAllPossibleRegions(this.props.gameClient.authenticatedPlayer.house)) {
-            if (!confirm('You haven\'t assigned an Order token to all of your areas. Continue anyway?')) {
-                return;
-            }
-        }
-
         this.props.gameState.ready();
     }
 }

--- a/agot-bg-game-server/tests/utils/setupGames.ts
+++ b/agot-bg-game-server/tests/utils/setupGames.ts
@@ -292,7 +292,8 @@ export function setupAtPlanningGameState(
         type: "planning",
         placedOrders: [],
         readyPlayers: [],
-        planningRestrictions: []
+        planningRestrictions: [],
+        bypassCanReady: true
     }, userSetupOptions).expectGameState<PlanningGameState>(PlanningGameState);
 }
 


### PR DESCRIPTION
Closes #99 

Might be a bit annoying when debugging but that's how it's written in the rules and you can then always return true in `checkAllRegionsHaveOrders`.