### PR TITLE
Fix sea regions can additionally raid land regions

### DIFF
--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -32,7 +32,6 @@ interface MapComponentProps {
 
 @observer
 export default class MapComponent extends Component<MapComponentProps> {
-    
     render(): ReactNode {
         return (
             <div className="map"

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/regionTypes.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/regionTypes.ts
@@ -3,7 +3,7 @@ import RegionKind from "./RegionKind";
 import BetterMap from "../../../utils/BetterMap";
 
 export const land = new RegionType("land", RegionKind.LAND);
-export const sea = new RegionType("sea", RegionKind.SEA);
+export const sea = new RegionType("sea", RegionKind.SEA, RegionKind.LAND);
 export const port = new RegionType("port", RegionKind.SEA);
 
 const regionTypes = new BetterMap<string, RegionType>([

--- a/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/PlanningGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/PlanningGameState.ts
@@ -146,8 +146,8 @@ export default class PlanningGameState extends GameState<IngameGameState> {
     /*
      * Common
      */
-    
-    canReady(house: House): {status: boolean; reason: string} {
+
+     canReady(house: House): {status: boolean; reason: string} {
         const possibleRegions = this.getPossibleRegionsForOrders(house);
 
         if (possibleRegions.every(r => this.placedOrders.has(r)))

--- a/agot-bg-game-server/src/server/server.ts
+++ b/agot-bg-game-server/src/server/server.ts
@@ -7,7 +7,6 @@ dotenv.config();
 // Setup Sentry
 if (process.env.SENTRY_DSN) {
     const SENTRY_DSN = process.env.SENTRY_DNS;
-    
     Sentry.init({dsn: SENTRY_DSN});
 }
 


### PR DESCRIPTION
I found this bug when playing around with "Removing unused raid orders“.