### PR TITLE
Disallow removing too much armies during supply reconciling

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/PlayerReconcileArmiesComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlayerReconcileArmiesComponent.tsx
@@ -44,7 +44,8 @@ export default class PlayerReconcileArmiesComponent extends Component<GameStateC
                                 ))}
                                 <Row className="justify-content-center">
                                     <Col xs="auto">
-                                        <Button disabled={!this.props.gameState.isEnoughToReconcile(this.unitsToRemove)} onClick={() => this.confirm()}>Confirm</Button>
+                                        <Button disabled={!this.props.gameState.isEnoughToReconcile(this.unitsToRemove)
+                                            || this.props.gameState.isTooMuchReconciled(this.unitsToRemove).status} onClick={() => this.confirm()}>Confirm</Button>
                                     </Col>
                                     <Col xs="auto">
                                         <Button disabled={this.unitsToRemove.size == 0} onClick={() => this.reset()}>Reset</Button>
@@ -91,7 +92,7 @@ export default class PlayerReconcileArmiesComponent extends Component<GameStateC
 
     modifyUnitsOnMap(): [Unit, PartialRecursive<UnitOnMapProperties>][] {
         if (this.props.gameClient.doesControlHouse(this.house)) {
-            return this.props.gameState.game.world.getUnitsOfHouse(this.house).map(u => [
+            return this.props.gameState.getPossibleUnitsToBeRemoved(this.house).map(u => [
                 u,
                 {
                     highlight: {active: !_.flatMap(this.unitsToRemove.map((_, us) => us)).includes(u)},

--- a/agot-bg-game-server/src/utils/getUniqueCombinations.ts
+++ b/agot-bg-game-server/src/utils/getUniqueCombinations.ts
@@ -1,0 +1,11 @@
+export const getUniqueCombinations = <T>(items: Array<Array<T>>, prepend: Array<T> = []): Array<Array<T>> => {
+    if (!items || items.length === 0) return [prepend];
+
+    let out: T[][] = [];
+
+    for (let i = 0; i < items[0].length; i++) {
+        out = [...out, ...getUniqueCombinations(items.slice(1), [...prepend, items[0][i]])];
+    }
+
+    return out;
+}


### PR DESCRIPTION
Closes #178 

I guess this is what you searched for and it is necessary for introducing vassals as we don't want a commander to remove all vassal units. It still allows removing a complete army in a region but it doesn't allow removing too much armies and single units anymore.

I decided to do the incremental approach region based instead of unit based as it was easier and we realized that rulebook doesn’t explicitly forbid deleting more units than necessary in a region. So I followed derangers suggestion to allow removing the whole army of a region but force user to keep at least one unit. 