### PR TITLE
Properly show the right Westeros Card image for cards of different decks

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -112,7 +112,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                     <>
                         <Row className="justify-content-center">
                             <Col xs="auto">
-                                <WesterosCardComponent cardType={westerosCardType} size="small" tooltip={true}/>
+                                <WesterosCardComponent cardType={westerosCardType} size="small" tooltip={true} westerosDeckI={data.westerosDeckI}/>
                             </Col>
                         </Row>
                     </>
@@ -129,7 +129,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                         <Row className="justify-content-around">
                             {drawnWesterosCardTypes.map((wct, i) => (
                                 <Col xs="auto" key={i}>
-                                    <WesterosCardComponent cardType={wct} size="small" tooltip={true} />
+                                    <WesterosCardComponent cardType={wct} size="small" tooltip={true} westerosDeckI={i} />
                                 </Col>
                             ))}
                         </Row>

--- a/agot-bg-game-server/src/client/game-state-panel/WesterosGameStateComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/WesterosGameStateComponent.tsx
@@ -37,7 +37,7 @@ export default class WesterosGameStateComponent extends Component<GameStateCompo
                     <ListGroupItem>
                         <Row className="justify-content-center">
                             <Col xs="auto">
-                                <WesterosCardComponent cardType={this.props.gameState.currentCard.type}/>
+                                <WesterosCardComponent cardType={this.props.gameState.currentCard.type} westerosDeckI={this.props.gameState.currentCardI}/>
                             </Col>
                         </Row>
                     </ListGroupItem>

--- a/agot-bg-game-server/src/client/game-state-panel/utils/WesterosCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/WesterosCardComponent.tsx
@@ -8,6 +8,7 @@ import westerosCardImages from "../../westerosCardImages";
 
 interface WesterosCardProps {
     cardType: WesterosCardType;
+    westerosDeckI: number;
     size?: "small" | "medium";
     tooltip?: boolean;
 }
@@ -21,7 +22,7 @@ export default class WesterosCardComponent extends Component<WesterosCardProps> 
                     this.props.tooltip ? <div
                         className="horizontal-game-card"
                         style={{
-                            backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.cardType.id)})` : undefined
+                            backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.westerosDeckI).get(this.props.cardType.id)})` : undefined
                         }}
                     /> : <div/>
                 }
@@ -32,7 +33,7 @@ export default class WesterosCardComponent extends Component<WesterosCardProps> 
                 <div
                     className={classNames("horizontal-game-card hover-weak-outline", this.props.size)}
                     style={{
-                        backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.cardType.id)})` : undefined
+                        backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.westerosDeckI).get(this.props.cardType.id)})` : undefined
                     }}
                 />
             </OverlayTrigger>

--- a/agot-bg-game-server/src/client/westerosCardImages.ts
+++ b/agot-bg-game-server/src/client/westerosCardImages.ts
@@ -4,6 +4,7 @@ import darkWingsDarkWords from "../../public/images/westeros-cards/DarkWingsDark
 import feastForCrows from "../../public/images/westeros-cards/FeastForCrows.png";
 import gameOfThrones from "../../public/images/westeros-cards/GameOfThrones.png";
 import lastDaysOfSummer from "../../public/images/westeros-cards/LastDaysSummer.png";
+import lastDaysOfSummerII from "../../public/images/westeros-cards/LastDaysSummerII.png";
 import mustering from "../../public/images/westeros-cards/Mustering.png";
 import putToTheSword from "../../public/images/westeros-cards/PutToTheSword.png";
 import rainsOfAutmun from "../../public/images/westeros-cards/RainsOfAutumn.png";
@@ -14,23 +15,32 @@ import throneOfBlades from "../../public/images/westeros-cards/ThoneOfBlades.png
 import webOfLies from "../../public/images/westeros-cards/WebOfLies.png";
 import wildlingsAttackIII from "../../public/images/westeros-cards/WildlingsAttackIII.png";
 import winterIsComing from "../../public/images/westeros-cards/WinterIsComing.png";
+import winterIsComingII from "../../public/images/westeros-cards/WinterComingII.png";
 
 const westerosCardImages = new BetterMap([
-    ["clash-of-kings", clashOfKings],
-    ["dark-wings-dark-words", darkWingsDarkWords],
-    ["feast-for-crows", feastForCrows],
-    ["game-of-thrones", gameOfThrones],
-    ["last-days-of-summer", lastDaysOfSummer],
-    ["mustering", mustering],
-    ["put-to-the-sword", putToTheSword],
-    ["rains-of-autumn", rainsOfAutmun],
-    ["sea-of-storms", seaOfStorms],
-    ["storm-of-swords", stormOfSwords],
-    ["supply", supply],
-    ["a-throne-of-blades", throneOfBlades],
-    ["web-of-lies", webOfLies],
-    ["wildlings-attack", wildlingsAttackIII],
-    ["winter-is-coming", winterIsComing]
+    [0, new BetterMap([
+        ["last-days-of-summer", lastDaysOfSummer],
+        ["mustering", mustering],
+        ["winter-is-coming", winterIsComing],
+        ["a-throne-of-blades", throneOfBlades],
+        ["supply", supply],
+    ])],
+    [1, new BetterMap([
+        ["game-of-thrones", gameOfThrones],
+        ["dark-wings-dark-words", darkWingsDarkWords],
+        ["winter-is-coming", winterIsComingII],
+        ["clash-of-kings", clashOfKings],
+        ["last-days-of-summer", lastDaysOfSummerII],
+    ])],
+    [2, new BetterMap([
+        ["feast-for-crows", feastForCrows],
+        ["put-to-the-sword", putToTheSword],
+        ["rains-of-autumn", rainsOfAutmun],
+        ["sea-of-storms", seaOfStorms],
+        ["storm-of-swords", stormOfSwords],
+        ["web-of-lies", webOfLies],
+        ["wildlings-attack", wildlingsAttackIII],
+    ])]
 ]);
 
 export default westerosCardImages;

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -65,6 +65,7 @@ interface MarchResolved {
 interface WesterosCardExecuted {
     type: "westeros-card-executed";
     westerosCardType: string;
+    westerosDeckI: number;
 }
 
 interface WesterosCardDrawn {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/westeros-card/WinterIsComingWesterosCardType.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/westeros-card/WinterIsComingWesterosCardType.ts
@@ -8,7 +8,8 @@ export default class WinterIsComingWesterosCardType extends WesterosCardType {
     executeImmediately(westerosGameState: WesterosGameState, currentDeckI: number): void {
         westerosGameState.ingame.log({
             type: "westeros-card-executed",
-            westerosCardType: winterIsComing.id
+            westerosCardType: winterIsComing.id,
+            westerosDeckI: currentDeckI
         });
 
         const deck = westerosGameState.game.westerosDecks[currentDeckI];

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/WesterosGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/WesterosGameState.ts
@@ -163,7 +163,8 @@ export default class WesterosGameState extends GameState<IngameGameState,
     executeCard(card: WesterosCard): void {
         this.ingame.log({
             type: "westeros-card-executed",
-            westerosCardType: card.type.id
+            westerosCardType: card.type.id,
+            westerosDeckI: this.currentCardI
         });
 
         card.type.execute(this);


### PR DESCRIPTION
Closes #287.

Unfortunately, this introduces a breaking change for the serialized game, as the GameLog "westeros-card-executed" requires the number of the Westeros deck to properly show the card. This will need to be changed for current live games.