### PR TITLE
Improve 'Resolve Consolidate Power Orders' to properly reproduce turn order in gamelog

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
@@ -109,10 +109,16 @@ export default class ActionGameState extends GameState<IngameGameState, UseRaven
             .map(([region, _order]) => region);
     }
 
-    getRegionsWithStarredConsolidatePowerOrderOfHouse(house: House): Region[] {
+    getRegionsWithConsolidatePowerOrderOfHouse(house: House): [Region, Order][] {
         return this.ordersOnBoard.entries
-            .filter(([region, _order]) => region.getController() == house)
-            .filter(([_region, order]) => order.type instanceof ConsolidatePowerOrderType && order.type.starred)
+            .filter(([region, order]) =>
+                region.getController() == house
+                && order.type instanceof ConsolidatePowerOrderType);
+    }
+
+    getRegionsWithStarredConsolidatePowerOrderOfHouse(house: House): Region[] {
+        return this.getRegionsWithConsolidatePowerOrderOfHouse(house)
+            .filter(([_region, order]) => order.type.starred)
             .map(([region, _order]) => region);
     }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/ResolveConsolidatePowerGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/ResolveConsolidatePowerGameState.ts
@@ -92,26 +92,26 @@ export default class ResolveConsolidatePowerGameState extends GameState<ActionGa
     }
 
     resolveConsolidatePowerOrderForPt(region: Region, house: House): void {
-        const gaines: number = this.getPotentialGainedPowerTokens(region, house);
+        const gains: number = this.getPotentialGainedPowerTokens(region, house);
 
-        if(gaines > 0) {
+        if(gains > 0) {
             // Broadcast new Power token count
-            house.changePowerTokens(gaines);
+            house.changePowerTokens(gains);
 
             this.entireGame.broadcastToClients({
                 type: "change-power-token",
                 houseId: house.id,
                 powerTokenCount: house.powerTokens
             });
-
-            this.ingame.log({
-                type: "consolidate-power-order-resolved",
-                house: house.id,
-                region: region.id,
-                starred: this.actionGameState.ordersOnBoard.get(region).type.starred,
-                powerTokenCount: gaines
-            });
         }
+
+        this.ingame.log({
+            type: "consolidate-power-order-resolved",
+            house: house.id,
+            region: region.id,
+            starred: this.actionGameState.ordersOnBoard.get(region).type.starred,
+            powerTokenCount: gains
+        });
     }
 
     proceedNextResolve(lastHouseToResolve: House | null): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/ResolveConsolidatePowerGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/ResolveConsolidatePowerGameState.ts
@@ -6,7 +6,6 @@ import {ServerMessage} from "../../../../messages/ServerMessage";
 import Game from "../../game-data-structure/Game";
 import ConsolidatePowerOrderType from "../../game-data-structure/order-types/ConsolidatePowerOrderType";
 import House from "../../game-data-structure/House";
-import BetterMap from "../../../../utils/BetterMap";
 import EntireGame from "../../../EntireGame";
 import {land, port, sea} from "../../game-data-structure/regionTypes";
 import PlayerMusteringGameState, {
@@ -40,26 +39,25 @@ export default class ResolveConsolidatePowerGameState extends GameState<ActionGa
         this.proceedNextResolve(null);
     }
 
-    resolveNormalConsolidatePowerOrders() {
+    resolveNormalConsolidatePowerOrders(): void {
         // If a house has no starred consolidate power order the normal consolidate power orders can be processed automatically
         // Resolve the normal consolidate power and give the power tokens for each house
-        const consolidatePowerOrders = this.actionGameState.ordersOnBoard.entries.filter(([region, order]) => order.type instanceof ConsolidatePowerOrderType);
+        const consolidatePowerOrders = this.actionGameState.ordersOnBoard.entries.filter(([_, order]) => order.type instanceof ConsolidatePowerOrderType);
 
         this.actionGameState.game.getTurnOrder().forEach(house => {
-            const ordersOfHouse = consolidatePowerOrders.filter(([region, order]) => region.getController() == house);
+            const ordersOfHouse = consolidatePowerOrders.filter(([region, _]) => region.getController() == house);
 
             if(ordersOfHouse.length == 0) {
                 return;
             }
 
-            const starredOrders = ordersOfHouse.filter(([region, order]) => order.type.starred);
+            const starredOrders = ordersOfHouse.filter(([_, order]) => order.type.starred);
 
             // If all consolidate power orders are not starred
             // or the starred consolidate power order is placed on a non castle region
             // this phase can be processed automatically
-            if(starredOrders.length == 0 || starredOrders.every(([region, order]) => !region.hasStructure)) {
-                ordersOfHouse.forEach(([region, order]) => {
-                    // Remember if the current order was a starred one for the game log
+            if(starredOrders.length == 0 || starredOrders.every(([region, _]) => !region.hasStructure)) {
+                ordersOfHouse.forEach(([region, _]) => {
                     this.resolveConsolidatePowerOrderForPt(region, house);
 
                     // Remove the consolidate power order from board
@@ -93,7 +91,7 @@ export default class ResolveConsolidatePowerGameState extends GameState<ActionGa
         return 0;
     }
 
-    resolveConsolidatePowerOrderForPt(region: Region, house: House) {
+    resolveConsolidatePowerOrderForPt(region: Region, house: House): void {
         const gaines: number = this.getPotentialGainedPowerTokens(region, house);
 
         if(gaines > 0) {


### PR DESCRIPTION
Fix #296 

Now Consolidate Power Orders will be processed automatically in respect to turn order. Note that still all Consolidate Power Orders of a house are still resolved at once (which differs from the rulebook but speeds up this phase) if user can't use a starred order for mustering.