### PR TITLE
Add Rumble in the South and Race to King's Landing variants

### DIFF
--- a/agot-bg-game-server/data/baseGameData.json
+++ b/agot-bg-game-server/data/baseGameData.json
@@ -7,32 +7,86 @@
     "kingsCourt": ["lannister", "stark", "martell", "baratheon", "tyrell", "greyjoy"]
   },
   "setups": {
-    "3": {
-      "houses": ["stark", "lannister", "baratheon"],
-      "blockedRegions": [
-        "pyke", "port-of-pyke", "highgarden", "oldtown", "port-of-oldtown", "sunspear",
-        "port-of-sunspear", "salt-shore", "yronwood", "starfall", "three-towers",
-        "dornish-marches", "princes-pass", "the-boneway", "storms-end", "port-of-storms-end"
-      ],
-      "removedUnits": ["port-of-lannisport"]
-    },
-    "4": {
-      "houses": ["stark", "greyjoy", "lannister", "baratheon"],
-      "blockedRegions": [
-        "highgarden", "oldtown", "port-of-oldtown", "sunspear", "port-of-sunspear", "salt-shore",
-        "yronwood", "starfall", "three-towers", "dornish-marches", "princes-pass", "the-boneway",
-        "storms-end", "port-of-storms-end"
+    "base-game": {
+      "name": "2nd Edition Base Game (3 or 6 players)",
+      "playerSetups": [
+        {
+          "playerCount": 3,
+          "houses": ["stark", "lannister", "baratheon"],
+          "blockedRegions": [
+            "pyke", "port-of-pyke", "highgarden", "oldtown", "port-of-oldtown", "sunspear",
+            "port-of-sunspear", "salt-shore", "yronwood", "starfall", "three-towers",
+            "dornish-marches", "princes-pass", "the-boneway", "storms-end", "port-of-storms-end"
+          ],
+          "removedUnits": ["port-of-lannisport"]
+        },
+        {
+          "playerCount": 6,
+          "houses": ["stark", "greyjoy", "lannister", "baratheon", "tyrell", "martell"]
+        }
       ]
     },
-    "5": {
-      "houses": ["stark", "greyjoy", "lannister", "baratheon", "tyrell"],
-      "blockedRegions": [
-        "sunspear", "port-of-sunspear", "salt-shore", "yronwood", "starfall",
-        "princes-pass", "the-boneway", "storms-end", "port-of-storms-end"
+    "struggle-in-the-north": {
+      "name": "Struggle in the North (4 or 5 players)",
+      "playerSetups": [
+        {
+          "playerCount": 4,
+          "houses": ["stark", "greyjoy", "lannister", "baratheon"],
+          "blockedRegions": [
+            "highgarden", "oldtown", "port-of-oldtown", "sunspear", "port-of-sunspear", "salt-shore",
+            "yronwood", "starfall", "three-towers", "dornish-marches", "princes-pass", "the-boneway",
+            "storms-end", "port-of-storms-end"
+          ]
+        },
+        {
+          "playerCount": 5,
+          "houses": ["stark", "greyjoy", "lannister", "baratheon", "tyrell"],
+          "blockedRegions": [
+            "sunspear", "port-of-sunspear", "salt-shore", "yronwood", "starfall",
+            "princes-pass", "the-boneway", "storms-end", "port-of-storms-end"
+          ]
+        }
       ]
     },
-    "6": {
-      "houses": ["stark", "greyjoy", "lannister", "baratheon", "tyrell", "martell"]
+    "rumble-in-the-south": {
+      "name": "Rumble in the South (4 players)",
+      "playerSetups": [
+        {
+          "playerCount": 4,
+          "houses": ["lannister", "baratheon", "tyrell", "martell"],
+          "blockedRegions": [
+            "bay-of-ice", "ironmans-bay", "flints-finger", "seagard", "the-narrow-sea",
+            "greywater-watch", "moat-cailin", "the-twins", "the-fingers", "the-eyrie",
+            "the-stony-shore", "winterfell", "port-of-winterfell", "white-harbor", "port-of-white-harbor",
+            "widows-watch", "castle-black", "karhold", "the-shivering-sea", "pyke", "port-of-pyke"
+          ]
+        }
+      ]
+    },
+    "race-to-kings-landing": {
+      "name": "Race to King's Landing (5 players)",
+      "playerSetups": [
+        {
+          "playerCount": 5,
+          "houses": ["lannister", "stark", "greyjoy", "tyrell", "martell"],
+          "blockedRegions": [
+            "dragonstone", "port-of-dragonstone"
+          ]
+        }
+      ]
+    },
+    "no-kraken-for-dinner": {
+      "name": "No Kraken for Dinner (5 players)",
+      "playerSetups": [
+        {
+          "playerCount": 5,
+          "houses": ["baratheon", "lannister", "stark", "tyrell", "martell"],
+          "blockedRegions": [
+            "pyke", "port-of-pyke"
+          ],
+          "removedUnits": ["port-of-lannisport"]
+        }
+      ]
     }
   },
   "units": {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
@@ -72,20 +72,20 @@ interface HouseCardData {
     ability?: string;
 }
 
+export interface GameSetupContainer {
+    name: string;
+    playerSetups: GameSetup[];
+}
+
 export interface GameSetup {
+    playerCount: number;
     houses: string[];
     blockedRegions?: string[];
     removedUnits?: string[];
 }
 
 export default function createGame(entireGame: EntireGame, housesToCreate: string[]): Game {
-    // Based on the number of players, find the corresponding setup
-    if (!baseGameData.setups.hasOwnProperty(housesToCreate.length.toString())) {
-        throw new Error();
-    }
-
-    // @ts-ignore
-    const gameSetup = entireGame.gameSetup;
+    const gameSetup = entireGame.getSelectedGameSetup();
 
     const game = new Game();
 

--- a/agot-bg-game-server/src/common/lobby-game-state/LobbyGameState.ts
+++ b/agot-bg-game-server/src/common/lobby-game-state/LobbyGameState.ts
@@ -29,7 +29,7 @@ export default class LobbyGameState extends GameState<EntireGame> {
     }
 
     getAvailableHouses(): LobbyHouse[] {
-        return this.lobbyHouses.values.filter(h => this.entireGame.gameSetup.houses.includes(h.id));
+        return this.lobbyHouses.values.filter(h => this.entireGame.getSelectedGameSetup().houses.includes(h.id));
     }
 
     onGameSettingsChange(): void {


### PR DESCRIPTION
Relates to #330 

I am not sure if that is exactly what you desired but it works. As always I am excited for your review and remarks what can be done better.

Note: Race to King's Landing needs a Kings Court modification because without the modification Lannister starts with 2 dominance tokens. As written on Board Game Geeks it's recommended to reduce winning count to 6 castles for Struggle in the South but maybe that causes confusion and we should start with 7 castles as usual and see how that works out?