### PR TITLE
Remove console.log which reveals the complete wildling deck

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -159,7 +159,6 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                     </>
                 );
             case "wildling-card-revealed":
-                console.log(this.game.wildlingDeck);
                 const wildlingCard = this.game.wildlingDeck.find(wc => wc.id == data.wildlingCard) as WildlingCard;
 
                 return (


### PR DESCRIPTION
The complete wildling deck is revealed on the console when a wilding card is revealed. We had Skinchangers scout and the next card was Silence at the wall like it is shown on console:

![image](https://user-images.githubusercontent.com/22304202/77070339-548cd180-69ea-11ea-9e95-3b3219567cc2.png)
