### PR TITLE
Fast-track unusable raid orders

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/ResolveSingleRaidOrderComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveSingleRaidOrderComponent.tsx
@@ -105,7 +105,7 @@ export default class ResolveSingleRaidOrderComponent extends Component<GameState
                 ])
             } else {
                 // Highlight the possible raidable orders from the select Raid order
-                return this.props.gameState.getRaidableRegions(this.selectedOrderRegion, this.orderInOrderRegion).map(r => [
+                return this.props.gameState.getRaidableRegions(this.selectedOrderRegion).map(r => [
                     r,
                     {highlight: {active: true}, onClick: () => this.onOrderClick(r)}
                 ])

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/ResolveRaidOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/ResolveRaidOrderGameState.ts
@@ -9,6 +9,8 @@ import House from "../../game-data-structure/House";
 import Player from "../../Player";
 import {ClientMessage} from "../../../../messages/ClientMessage";
 import {ServerMessage} from "../../../../messages/ServerMessage";
+import RaidOrderType from "../../game-data-structure/order-types/RaidOrderType";
+import Region from "../../game-data-structure/Region";
 
 export default class ResolveRaidOrderGameState extends GameState<ActionGameState, ResolveSingleRaidOrderGameState> {
     get actionGameState(): ActionGameState {
@@ -35,13 +37,57 @@ export default class ResolveRaidOrderGameState extends GameState<ActionGameState
         this.proceedNextResolveSingleRaidOrder(null);
     }
 
+    getRaidableRegions(orderRegion: Region): Region[] {
+        const order = this.getRaidOrder(orderRegion);
+
+        if (!order) {
+            return [];
+        }
+
+        // getController() can safely be casted here as a region with an order always has a controller
+        const orderRegionController = orderRegion.getController() as House;
+
+        return this.world.getNeighbouringRegions(orderRegion)
+            .filter(r => r.getController() != orderRegionController)
+            .filter(r => this.actionGameState.ordersOnBoard.has(r))
+            .filter(r => order.isValidRaidableOrder(this.actionGameState.ordersOnBoard.get(r)))
+            .filter(r => r.type.kind == orderRegion.type.kind || orderRegion.type.canAdditionalyRaid == r.type.kind);
+    }
+
+    private canRegionWithRaidOrderBeRaidedByEnemiesRaidOrder(region: Region): boolean {
+        const order = this.getRaidOrder(region);
+
+        if (!order) {
+            throw new Error("A raid order has to be present in the given region!");
+        }
+
+        // getController() can be safely cast here as a region with an order must have a controller
+        const controller = region.getController() as House;
+
+        // Get neighbouring regions with enemy raid orders
+        const adjectRegionsWithRaidOrders = this.world.getNeighbouringRegions(region)
+                                                .filter(r => r.getController() != controller)
+                                                .filter(r => this.getRaidOrder(r) != null);
+
+        return adjectRegionsWithRaidOrders.some(r => this.getRaidableRegions(r).includes(region));
+    }
+
+    private getRaidOrder(region: Region): RaidOrderType | null {
+        const order = this.actionGameState.ordersOnBoard.tryGet(region, null);
+
+        if (order && (order.type instanceof RaidOrderType)) {
+            return order.type;
+        }
+
+        return null;
+    }
+
     onPlayerMessage(player: Player, message: ClientMessage): void {
         this.childGameState.onPlayerMessage(player, message);
     }
 
     onServerMessage(message: ServerMessage): void {
         this.childGameState.onServerMessage(message);
-
     }
 
     onResolveSingleRaidOrderGameStateEnd(house: House): void {
@@ -59,7 +105,38 @@ export default class ResolveRaidOrderGameState extends GameState<ActionGameState
             return;
         }
 
-        this.setChildGameState(new ResolveSingleRaidOrderGameState(this)).firstStart(houseToResolve);
+        const allRaidOrderRegions = this.actionGameState.getRegionsWithRaidOrderOfHouse(houseToResolve);
+
+        if(allRaidOrderRegions.length == 0) {
+            throw new Error("At that point at least one region with a raid order must be present!");
+        }
+
+        // Before asking the player to resolve a Raid order,
+        // check if they only have unusuable raid orders which can't be raided themselves.
+        // In that case, fast-track the process and simply resolve one of those.
+        if (allRaidOrderRegions.every(r => this.getRaidableRegions(r).length == 0 && !this.canRegionWithRaidOrderBeRaidedByEnemiesRaidOrder(r))) {
+            const regionWhereRaidOrderCanBeRemoved = allRaidOrderRegions[0];
+
+            this.ingameGameState.log({
+                type: "raid-done",
+                raider: (regionWhereRaidOrderCanBeRemoved.getController() as House).id, // can safely casted here as region has an order and therefore it mus be controlled
+                raiderRegion: regionWhereRaidOrderCanBeRemoved.id,
+                raidedRegion: null,
+                raidee: null,
+                orderRaided: null
+            });
+
+            this.actionGameState.ordersOnBoard.delete(regionWhereRaidOrderCanBeRemoved);
+            this.entireGame.broadcastToClients({
+                type: "action-phase-change-order",
+                region: regionWhereRaidOrderCanBeRemoved.id,
+                order: null
+            });
+
+            this.proceedNextResolveSingleRaidOrder(houseToResolve);
+        } else {
+            this.setChildGameState(new ResolveSingleRaidOrderGameState(this)).firstStart(houseToResolve);
+        }
     }
 
     getNextHouseToResolveRaidOrder(lastHouseToResolve: House | null): House | null {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
@@ -10,7 +10,6 @@ import Game from "../../../game-data-structure/Game";
 import World from "../../../game-data-structure/World";
 import IngameGameState from "../../../IngameGameState";
 import ActionGameState from "../../ActionGameState";
-import RaidOrderType from "../../../game-data-structure/order-types/RaidOrderType";
 import ConsolidatePowerOrderType from "../../../game-data-structure/order-types/ConsolidatePowerOrderType";
 import User from "../../../../../server/User";
 
@@ -62,12 +61,10 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
                 return;
             }
 
-            const orderType = this.actionGameState.ordersOnBoard.get(orderRegion).type as RaidOrderType;
-
             if (targetRegion) {
                 const orderTarget = this.actionGameState.ordersOnBoard.get(targetRegion);
 
-                if (!this.getRaidableRegions(orderRegion, orderType).includes(targetRegion)) {
+                if (!this.getRaidableRegions(orderRegion).includes(targetRegion)) {
                     return;
                 }
 
@@ -143,12 +140,8 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
 
     }
 
-    getRaidableRegions(orderRegion: Region, raid: RaidOrderType): Region[] {
-        return this.world.getNeighbouringRegions(orderRegion)
-            .filter(r => r.getController() != this.house)
-            .filter(r => this.actionGameState.ordersOnBoard.has(r))
-            .filter(r => raid.isValidRaidableOrder(this.actionGameState.ordersOnBoard.get(r)))
-            .filter(r => r.type.kind == orderRegion.type.kind || orderRegion.type.canAdditionalyRaid == r.type.kind);
+    getRaidableRegions(orderRegion: Region): Region[] {
+        return this.resolveRaidOrderGameState.getRaidableRegions(orderRegion);
     }
 
     resolveRaid(orderRegion: Region, targetRegion: Region | null): void {


### PR DESCRIPTION
Relates to #95 

I followed your example when resolving a CP order and did it here the same way:

![raid-map](https://user-images.githubusercontent.com/22304202/77086707-6a0df580-6a02-11ea-8100-2c42a1691069.PNG)

![image](https://user-images.githubusercontent.com/22304202/77086728-6f6b4000-6a02-11ea-8f1b-90ecc060ceb7.png)


The marked lines have been fast-tracked.
