### PR TITLE
Fast-track SelectUnitsGameState when countToSelect equals possibleUnits.length

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/select-units-game-state/SelectUnitsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/select-units-game-state/SelectUnitsGameState.ts
@@ -28,6 +28,15 @@ export default class SelectUnitsGameState<P extends SelectUnitsParentGameState> 
     }
 
     firstStart(house: House, possibleUnits: Unit[], count: number, canBeSkipped = false): void {
+        if (count > possibleUnits.length) {
+            throw new Error("User has to select more units than possible and therefore SelectUnitsGameState will never end!");
+        }
+
+        if (!canBeSkipped && possibleUnits.length == count) {
+            this.parentGameState.onSelectUnitsEnd(house, this.convertPossibleUnitsForOnSelectUnitsEnd(possibleUnits));
+            return;
+        }
+
         this.house = house;
         this.possibleUnits = possibleUnits;
         this.count = count;
@@ -88,6 +97,23 @@ export default class SelectUnitsGameState<P extends SelectUnitsParentGameState> 
 
     canPickUnit(u: Unit): boolean {
         return this.possibleUnits.includes(u);
+    }
+
+    private convertPossibleUnitsForOnSelectUnitsEnd(units: Unit[]): [Region, Unit[]][] {
+        const unitsMap = new BetterMap<Region, Unit[]>();
+
+        units.forEach(u => {
+            const r = u.region;
+            const tmp = unitsMap.tryGet(r, null);
+            if (tmp) {
+                tmp.push(u);
+                unitsMap.set(r, tmp);
+            } else {
+                unitsMap.set(r, Array.of(u));
+            }
+        });
+
+        return unitsMap.entries;
     }
 
     serializeToClient(_admin: boolean, _player: Player | null): SerializedSelectUnitsGameState {


### PR DESCRIPTION
Relates to #95  
I received three independent feedbacks that actions where the user has just one possibility should be done automatically and as mentioned in the issue I feel with the users. It's just annoying opening a game and do a obvious move like removing an unusable raid order or killing a unit with Mace Tyrell or degrading a knight, if there is only one... So over night I had the idea to always fast-track SelectUnitsGameState when possibleUnits.length == count. This would cover some GameStates like CrowKillersNightwatchsVictory completely without extra handling there and other game states like Mace Tyrell would just need to pass one of the opponents footman to SelectUnitsGameState. What do you think about this idea?