### PR TITLE
Refactor orphaned ship handling to call it after a Wildlings attack also

### DIFF
--- a/agot-bg-game-server/package.json
+++ b/agot-bg-game-server/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "run-client": "webpack-dev-server --config webpack.client.js --mode=development",
     "build-client": "webpack --config webpack.client.js --mode=production",
-    "run-server": "ts-node src/server/server.ts",
+    "run-server": "ts-node -T src/server/server.ts",
     "generate-json-schemas": "typescript-json-schema --strict-null-checks src/messages/ClientMessage.ts ClientMessage -o src/server/ClientMessage.json --include src/messages/*.ts",
     "lint": "eslint . --ext .ts,.tsx"
   }

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/ResolveMarchOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/ResolveMarchOrderGameState.ts
@@ -15,6 +15,7 @@ import Game from "../../game-data-structure/Game";
 import Order from "../../game-data-structure/Order";
 import { port } from "../../game-data-structure/regionTypes";
 import TakeControlOfEnemyPortGameState, { SerializedTakeControlOfEnemyPortGameState } from "./take-control-of-enemy-port-game-state/TakeControlOfEnemyPortGameState";
+import { findOrphanedShipsAndDestroyThem } from "../../port-helper/PortHelper";
 
 export default class ResolveMarchOrderGameState extends GameState<ActionGameState, ResolveSingleMarchOrderGameState | CombatGameState | TakeControlOfEnemyPortGameState> {
     constructor(actionGameState: ActionGameState) {
@@ -48,6 +49,8 @@ export default class ResolveMarchOrderGameState extends GameState<ActionGameStat
     onResolveSingleMarchOrderGameStateFinish(house: House): void {
         // Last march is completely handled
         // Now is the time to ...
+        //   ... destroy orphaned ships (e.g. caused by Arianne)
+        findOrphanedShipsAndDestroyThem(this.world, this.ingameGameState, this.actionGameState);
         //   ... check if ships can be converted
         const analyzePortResult = this.isTakeControlOfEnemyPortGameStateRequired();
         if(analyzePortResult) {
@@ -80,35 +83,6 @@ export default class ResolveMarchOrderGameState extends GameState<ActionGameStat
         }
 
         this.setChildGameState(new ResolveSingleMarchOrderGameState(this)).firstStart(houseToResolve);
-    }
-
-    destroyAllShipsInPort(portRegion: Region): number {
-        if(portRegion.type != port) {
-            throw new Error("This method is intended to only be used for destroying ships in ports")
-        }
-
-        this.removePossibleOrdersInPort(portRegion);
-
-        const house = portRegion.units.size > 0 ? portRegion.units.values[0].allegiance : null;
-        const shipsToDestroy = portRegion.units.map((id, _unit) => id);
-        shipsToDestroy.forEach(id => portRegion.units.delete(id));
-
-        if (house) {
-            this.entireGame.broadcastToClients({
-                type: "combat-change-army",
-                region: portRegion.id,
-                house: house.id,
-                army: []
-            });
-        }
-
-        this.entireGame.broadcastToClients({
-            type: "remove-units",
-            regionId: portRegion.id,
-            unitIds: shipsToDestroy
-        });
-
-        return shipsToDestroy.length;
     }
 
     proceedToCombat(attackerComingFrom: Region, combatRegion: Region, attacker: House, defender: House, army: Unit[], order: Order): void {
@@ -172,28 +146,13 @@ export default class ResolveMarchOrderGameState extends GameState<ActionGameStat
         });
     }
 
-    private removePossibleOrdersInPort(portRegion: Region): void {
-        if(portRegion.type != port) {
-            throw new Error("This method is intended to only be used for removing orders of destroyed or taken ships")
-        }
-
-        if (this.actionGameState.ordersOnBoard.has(portRegion)) {
-            this.actionGameState.ordersOnBoard.delete(portRegion);
-            this.entireGame.broadcastToClients({
-                type: "action-phase-change-order",
-                region: portRegion.id,
-                order: null
-            });
-        }
-    }
-
-    private isTakeControlOfEnemyPortGameStateRequired(): {port: Region; newController: House} | null {
+    private isTakeControlOfEnemyPortGameStateRequired(): { port: Region; newController: House } | null {
         // Find ports with enemy ships
         const portsWithEnemyShips = this.world.regions.values.filter(r => r.type == port
             && r.units.size > 0
             && r.getController() != this.world.getAdjacentLandOfPort(r).getController());
 
-            if(portsWithEnemyShips.length == 0) {
+        if (portsWithEnemyShips.length == 0) {
             return null;
         }
 
@@ -203,8 +162,6 @@ export default class ResolveMarchOrderGameState extends GameState<ActionGameStat
 
         if (adjacentCastleController) {
             // A castle with ships in port has been conquered
-            this.removePossibleOrdersInPort(portRegion);
-
             // return TakeControlOfEnemyPortGameState required
             return {
                 port: portRegion,
@@ -212,20 +169,8 @@ export default class ResolveMarchOrderGameState extends GameState<ActionGameStat
             }
         }
 
-        // When we reach this line the only way right now a orphaned ship can exist in a port
-        // is Martell playing Arianne in a non-capital city. So the ships have to be destroyed
-        const houseThatLostShips = portRegion.units.values[0].allegiance;
-
-        const destroyedShipCount = this.destroyAllShipsInPort(portRegion);
-        this.ingameGameState.log({
-            type: "ships-destroyed-by-empty-castle",
-            castle: adjacentCastle.name,
-            house: houseThatLostShips.name,
-            port: portRegion.name,
-            shipCount: destroyedShipCount
-        });
-
-        return null;
+        // We should never reach this line because we removed orphaned ships earlier.
+        throw new Error(`$Port with id '{portRegion.id}' contains orphaned ships which should have been removed before!`);
     }
 
     onPlayerMessage(player: Player, message: ClientMessage): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/take-control-of-enemy-port-game-state/TakeControlOfEnemyPortGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/take-control-of-enemy-port-game-state/TakeControlOfEnemyPortGameState.ts
@@ -13,6 +13,7 @@ import BetterMap from "../../../../../utils/BetterMap";
 import UnitType from "../../../game-data-structure/UnitType";
 import Unit from "../../../game-data-structure/Unit";
 import ResolveMarchOrderGameState from "../ResolveMarchOrderGameState";
+import { destroyAllShipsInPort } from "../../../port-helper/PortHelper";
 
 export default class TakeControlOfEnemyPortGameState extends GameState<ResolveMarchOrderGameState, SimpleChoiceGameState> {
     port: Region;
@@ -70,7 +71,7 @@ export default class TakeControlOfEnemyPortGameState extends GameState<ResolveMa
     onSimpleChoiceGameStateEnd(choice: number): void {
         // Remove ships from old controller
         const oldController = this.port.units.values[0].allegiance;
-        this.parentGameState.destroyAllShipsInPort(this.port);
+        destroyAllShipsInPort(this.port, this.entireGame, this.parentGameState.actionGameState);
 
         if(choice > 0) {
             // Add ships for new controller

--- a/agot-bg-game-server/src/common/ingame-game-state/port-helper/PortHelper.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/port-helper/PortHelper.ts
@@ -1,0 +1,72 @@
+import World from "../game-data-structure/World";
+import { port } from "../game-data-structure/regionTypes";
+import Region from "../game-data-structure/Region";
+import ActionGameState from "../action-game-state/ActionGameState";
+import IngameGameState from "../IngameGameState";
+import EntireGame from "../../../common/EntireGame";
+
+function removePossibleOrdersInPort(portRegion: Region, actionGameState: ActionGameState | null): void {
+    if (portRegion.type != port) {
+        throw new Error("This method is intended to only be used for removing orders of destroyed or taken ships")
+    }
+
+    if (!actionGameState) {
+        return;
+    }
+
+    if (actionGameState.ordersOnBoard.has(portRegion)) {
+        actionGameState.ordersOnBoard.delete(portRegion);
+        actionGameState.entireGame.broadcastToClients({
+            type: "action-phase-change-order",
+            region: portRegion.id,
+            order: null
+        });
+    }
+}
+
+export function destroyAllShipsInPort(portRegion: Region, entireGame: EntireGame, actionGameState: ActionGameState | null): number {
+    if (portRegion.type != port) {
+        throw new Error("This method is intended to only be used for destroying ships in ports")
+    }
+
+    removePossibleOrdersInPort(portRegion, actionGameState);
+
+    const house = portRegion.units.size > 0 ? portRegion.units.values[0].allegiance : null;
+    const shipsToDestroy = portRegion.units.map((id, _unit) => id);
+    shipsToDestroy.forEach(id => portRegion.units.delete(id));
+
+    if (house) {
+        entireGame.broadcastToClients({
+            type: "combat-change-army",
+            region: portRegion.id,
+            house: house.id,
+            army: []
+        });
+    }
+
+    entireGame.broadcastToClients({
+        type: "remove-units",
+        regionId: portRegion.id,
+        unitIds: shipsToDestroy
+    });
+
+    return shipsToDestroy.length;
+}
+
+export function findOrphanedShipsAndDestroyThem(world: World, ingameGameState: IngameGameState, actionGameState: ActionGameState | null): void {
+    const portsWithOrphanedShips = world.regions.values.filter(r => r.type == port
+        && r.units.size > 0
+        && !world.getAdjacentLandOfPort(r).getController());
+
+    portsWithOrphanedShips.forEach(portRegion => {
+        const houseThatLostShips = portRegion.units.values[0].allegiance;
+        const destroyedShipCount = destroyAllShipsInPort(portRegion, ingameGameState.entireGame, actionGameState);
+        ingameGameState.log({
+            type: "ships-destroyed-by-empty-castle",
+            castle: world.getAdjacentLandOfPort(portRegion).name,
+            house: houseThatLostShips.name,
+            port: portRegion.name,
+            shipCount: destroyedShipCount
+        });
+    })
+}

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingCardEffectInTurnOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingCardEffectInTurnOrderGameState.ts
@@ -2,6 +2,7 @@ import GameState from "../../../GameState";
 import WildlingsAttackGameState from "./WildlingsAttackGameState";
 import Game from "../../game-data-structure/Game";
 import House from "../../game-data-structure/House";
+import { findOrphanedShipsAndDestroyThem } from "../../port-helper/PortHelper";
 
 /**
  * A lot of Wildling Cards have the same logic where the lowest bidder
@@ -29,6 +30,10 @@ export default abstract class WildlingCardEffectInTurnOrderGameState<C extends G
     }
 
     proceedNextHouse(previousHouse: House | null): void {
+        // Some wildlings effects may cause units to be killed.
+        // Therefore an orphaned ship may be present here. Try to find it and destroy it in that case
+        findOrphanedShipsAndDestroyThem(this.game.world, this.parentGameState.ingame, null);
+
         if (previousHouse == null) {
             this.executeForLowestBidder(this.parentGameState.lowestBidder);
             return;

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/preemptive-raid-wildling-victory-game-state/PreemptiveRaidWildlingVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/preemptive-raid-wildling-victory-game-state/PreemptiveRaidWildlingVictoryGameState.ts
@@ -11,6 +11,7 @@ import SelectUnitsGameState, {SerializedSelectUnitsGameState} from "../../../sel
 import Unit from "../../../game-data-structure/Unit";
 import Region from "../../../game-data-structure/Region";
 import IngameGameState from "../../../IngameGameState";
+import { findOrphanedShipsAndDestroyThem } from "../../../port-helper/PortHelper";
 
 enum PreemptiveRaidStep {
     CHOOSING,
@@ -112,6 +113,9 @@ export default class PreemptiveRaidWildlingVictoryGameState extends GameState<Wi
             house: house.id,
             units: units.map(([region, units]) => [region.id, units.map(u => u.type.id)])
         });
+
+        // After destroying an unit an orphaned ship may be present here, so try to find it and destroy it in that case
+        findOrphanedShipsAndDestroyThem(this.game.world, this.ingame, null);
 
         this.parentGameState.onWildlingCardExecuteEnd();
     }


### PR DESCRIPTION
Closes #377 
Closes #415

A few things

- This is a qnd approach how this code part could be improved to be reused everywhere
- Of course I could replace the static methods by instance methods, just the invocation would look different
- As mentioned in the issue, handling orphaned ships during resolve march must be done in `ResolveSingleMarchOrderGameState` because it is too late after the march is done (attacker might have retreated to the empty castle)
- I decided to call `findOrphanedShipsAndDestroyThem(...)` after any wildling card has been executed. That will cause that a possible orphaned ship might lead to confusion as it will be removed after all houses have executed the effect. From code point it is a bit easier this way, otherwise I would have to integrate this into "Crow Killers", "Horde Decends", "Mammoth riders" and "Preemptive raid" directly. What to do you think?
- Local tests pending