### PR TITLE
PR #455 Always remove order after battle

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
@@ -234,11 +234,8 @@ export default class PostCombatGameState extends GameState<
             // It might be that this movement can be prevented by house cards (e.g. Arianne Martell)
             if (!this.isAttackingArmyMovementPrevented()) {
                 this.combat.resolveMarchOrderGameState.moveUnits(this.combat.attackingRegion, this.combat.attackingArmy, this.combat.defendingRegion);
-            } else {
-                // Defender had to retreat
-                // Therefore possible orders in defending region need to be removed
-                this.removeOrderFromRegion(this.combat.defendingRegion);
             }
+            this.removeOrderFromRegion(this.combat.defendingRegion);
         }
 
         // Remove the order from attacking region


### PR DESCRIPTION
When user move army then we should always remove any order from
conquered region. Without that, when a player reconquered his capital
(which has something like a 'supertoken') a order of defeated player
will be not removed.