### PR TITLE
Fix support being marched into is not taken into account against neutral forces

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
@@ -19,7 +19,6 @@ import Game from "../game-data-structure/Game";
 import ResolveConsolidatePowerGameState, {SerializedResolveConsolidatePowerGameState} from "./resolve-consolidate-power-game-state/ResolveConsolidatePowerGameState";
 import ConsolidatePowerOrderType from "../game-data-structure/order-types/ConsolidatePowerOrderType";
 import SupportOrderType from "../game-data-structure/order-types/SupportOrderType";
-import * as _ from "lodash";
 import {port, sea, land} from "../game-data-structure/regionTypes";
 import PlanningRestriction from "../game-data-structure/westeros-card/planning-restriction/PlanningRestriction";
 import planningRestrictions from "../game-data-structure/westeros-card/planning-restriction/planningRestrictions";
@@ -132,13 +131,6 @@ export default class ActionGameState extends GameState<IngameGameState, UseRaven
             // A sea battle can't be supported by land units
             .filter(r => !(attackedRegion.type == sea && r.type == land))
             .map(region => ({region, support: this.ordersOnBoard.get(region).type as SupportOrderType}));
-    }
-
-    getSupportCombatStrength(supportingHouse: House, attackedRegion: Region): number {
-        return this.getPossibleSupportingRegions(attackedRegion)
-            .filter(({region}) => region.getController() == supportingHouse)
-            .map(({region, support}) => this.game.getCombatStrengthOfArmy(region.units.values, attackedRegion.hasStructure) + support.supportModifier)
-            .reduce(_.add, 0);
     }
 
     serializeToClient(admin: boolean, player: Player | null): SerializedActionGameState {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
@@ -80,7 +80,7 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
             }
 
             // Check that at most one move triggers a fight
-            const movesThatTriggerAttack = moves.filter(([region, _army]) => this.doesMoveTriggerAttack(region));
+            const movesThatTriggerAttack = this.getMovesThatTriggerAttack(moves);
             // This has been checked earlier in "this.areValidMoves" but it's never bad
             // to check twice
             if (movesThatTriggerAttack.length > 1) {
@@ -286,6 +286,7 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
      */
     getValidTargetRegions(startingRegion: Region, moves: [Region, Unit[]][], movingArmy: Unit[]): Region[] {
         const movesThatTriggerAttack = this.getMovesThatTriggerAttack(moves);
+        const movesThatDontTriggerAttack = _.difference(moves, movesThatTriggerAttack);
         const attackMoveAlreadyPresent = movesThatTriggerAttack.length > 0;
 
         return this.world.getReachableRegions(startingRegion, this.house, movingArmy)
@@ -302,7 +303,7 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
             // to overcome the neutral force
             .filter(r => {
                 if (r.getController() == null && r.garrison > 0) {
-                    return this.hasEnoughToAttackNeutralForce(startingRegion, movingArmy, r);
+                    return this.hasEnoughToAttackNeutralForce(startingRegion, movingArmy, r, movesThatDontTriggerAttack);
                 }
 
                 return true;
@@ -334,16 +335,38 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
         return this.actionGameState.getRegionsWithMarchOrderOfHouse(this.house);
     }
 
-    hasEnoughToAttackNeutralForce(startingRegion: Region, army: Unit[], targetRegion: Region): boolean {
+    hasEnoughToAttackNeutralForce(startingRegion: Region, army: Unit[], targetRegion: Region, movesThatDontTriggerAttack: [Region, Unit[]][]): boolean {
         const marchOrder = this.actionGameState.ordersOnBoard.get(startingRegion);
 
         if (!(marchOrder.type instanceof MarchOrderType)) {
             throw new Error();
         }
 
-        return this.game.getCombatStrengthOfArmy(army, targetRegion.hasStructure)
-            + this.actionGameState.getSupportCombatStrength(this.house, targetRegion)
+        return this.getCombatStrengthOfArmyAgainstNeutralForce(army, targetRegion.hasStructure)
+            + this.getSupportCombatStrengthAgainstNeutralForce(this.house, targetRegion, movesThatDontTriggerAttack)
             + marchOrder.type.attackModifier >= targetRegion.garrison;
+    }
+
+    private getCombatStrengthOfArmyAgainstNeutralForce(army: Unit[], attackingAStructure: boolean, additionalSupportingUnits: Unit[] | null = null): number {
+        let strength = army
+            .filter(u => !u.wounded)
+            .map(u => u.getCombatStrength(attackingAStructure))
+            .reduce(_.add, 0);
+
+        if (additionalSupportingUnits) {
+            // Additional supporting units can't be wounded so we don't need that filter here
+            strength += additionalSupportingUnits.map(u => u.getCombatStrength(attackingAStructure)).reduce(_.add, 0);
+        }
+
+        return strength;
+    }
+
+    private getSupportCombatStrengthAgainstNeutralForce(supportingHouse: House, attackedRegion: Region, movesThatDontTriggerAttack: [Region, Unit[]][]): number {
+        const movesThatDontTriggerAttackMap = new BetterMap(movesThatDontTriggerAttack);
+        return this.actionGameState.getPossibleSupportingRegions(attackedRegion)
+            .filter(({region}) => region.getController() == supportingHouse)
+            .map(({region, support}) => this.getCombatStrengthOfArmyAgainstNeutralForce(region.units.values, attackedRegion.hasStructure, movesThatDontTriggerAttackMap.tryGet(region, null)) + support.supportModifier)
+            .reduce(_.add, 0);
     }
 
     sendMoves(startingRegion: Region, moves: BetterMap<Region, Unit[]>, leavePowerToken: boolean): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -298,13 +298,6 @@ export default class Game {
         return this.starredOrderRestrictions[place];
     }
 
-    getCombatStrengthOfArmy(army: Unit[], attackingAStructure: boolean): number {
-        return army
-            .filter(u => !u.wounded)
-            .map(u => u.getCombatStrength(attackingAStructure))
-            .reduce(_.add, 0);
-    }
-
     serializeToClient(admin: boolean): SerializedGame {
         return {
             lastUnitId: this.lastUnitId,


### PR DESCRIPTION
Closes #423 

I don't know if that is the best solution to solve it but it does the trick. As always I am open for suggestions to improve it.
I decided to refactor the neutral force code a bit as it might be misleading that there are 2 different methods for getCombatStrength. I think it's a bit more clear now.