### PR TITLE
Fixed a bug causing Roose Bolton's ability not to trigger under certa…

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
@@ -39,14 +39,14 @@ export default class RenlyBaratheonAbilityGameState extends GameState<
                 house: house.id
             });
 
-            this.parentGameState.parentGameState.onHouseCardResolutionFinish();
+            this.parentGameState.onHouseCardResolutionFinish(house);
         } else if (upgradableFootmen.length == 0) {
             this.ingame.log({
                 type: "renly-baratheon-no-footman-available",
                 house: house.id
             });
 
-            this.parentGameState.parentGameState.onHouseCardResolutionFinish();
+            this.parentGameState.onHouseCardResolutionFinish(house);
         } else {
             this.setChildGameState(new SelectUnitsGameState(this))
                 .firstStart(house, upgradableFootmen, 1, true);

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/CerseiLannisterHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/CerseiLannisterHouseCardAbility.ts
@@ -15,6 +15,7 @@ export default class CerseiLannisterHouseCardAbility extends HouseCardAbility {
                 .firstStart(house);
             return;
         }
-        afterWinnerDetermination.onHouseCardResolutionFinish();
+
+        afterWinnerDetermination.childGameState.onHouseCardResolutionFinish(house);
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/RenlyBaratheonHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/RenlyBaratheonHouseCardAbility.ts
@@ -15,6 +15,6 @@ export default class RenlyBaratheonHouseCardAbility extends HouseCardAbility {
             return;
         }
         
-        afterWinnerDetermination.onHouseCardResolutionFinish();
+        afterWinnerDetermination.childGameState.onHouseCardResolutionFinish(house);
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/TywinLannisterHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/TywinLannisterHouseCardAbility.ts
@@ -16,6 +16,6 @@ export default class TywinLannisterHouseCardAbility extends HouseCardAbility {
             });
         }
 
-        afterWinnerDetermination.onHouseCardResolutionFinish();
+        afterWinnerDetermination.childGameState.onHouseCardResolutionFinish(house);
     }
 }


### PR DESCRIPTION
Fixes #451 

As far as I could tell, the source of the issue is calling directly AfterWinnerDeterminationGameState's onHouseCardResolutionFinish method, which skips the following cards into the retreat phase. 

I changed it to call the child HouseCardResolutionGameState's onHouseCardResolutionFinish, and it seems to work.
In addition, I searched for other occurances of the same situation and changed them as well.
