### PR TITLE
Automatically grant own support of attacker and defender and allow refusing support

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -79,6 +79,11 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                     return <><b>{supporter.name}</b> supported no-one.</>;
                 }
 
+            case "support-refused": {
+                const house = this.game.houses.get(data.house);
+                return <>House <b>{house.name}</b> chose to refuse all the support they received.</>;
+            }
+
             case "attack":
                 const attacker = this.game.houses.get(data.attacker);
                 // A "null" for "attacked" means it was an attack against a neutral force

--- a/agot-bg-game-server/src/client/game-state-panel/ChooseHouseCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ChooseHouseCardComponent.tsx
@@ -13,13 +13,20 @@ import { observable } from "mobx";
 
 @observer
 export default class ChooseHouseCardComponent extends Component<GameStateComponentProps<ChooseHouseCardGameState>> {
-    @observable selectedHouseCard: HouseCard | null;
     @observable dirty: boolean;
 
     get chosenHouseCard(): HouseCard | null {
         return this.props.gameClient.authenticatedPlayer
             ? this.props.gameState.houseCards.tryGet(this.props.gameClient.authenticatedPlayer.house, null)
             : null;
+    }
+
+    get selectedHouseCard(): HouseCard | null {
+        return this.props.gameState.selectedHouseCard;
+    }
+
+    set selectedHouseCard(value: HouseCard | null) {
+        this.props.gameState.selectedHouseCard = value;
     }
 
     constructor(props: GameStateComponentProps<ChooseHouseCardGameState>) {
@@ -62,9 +69,24 @@ export default class ChooseHouseCardComponent extends Component<GameStateCompone
                             </Row>
                         </Col>
                         <Col xs={12}>
-                                <Button onClick={() => this.chooseHouseCard()} disabled={!this.dirty}>
-                                    Confirm
-                                </Button>
+                            <Row className="justify-content-center">
+                                <Col xs="auto">
+                                    <Button onClick={() => this.chooseHouseCard()} disabled={!this.dirty || this.selectedHouseCard == null}>
+                                        Confirm
+                                    </Button>
+                                </Col>
+                                {this.props.gameClient.authenticatedPlayer &&
+                                <Col xs="auto">
+                                    <Button onClick={() => {
+                                            if (window.confirm("Are you sure you want to refuse all the support you have received?")) {
+                                                this.props.gameState.refuseSupport();
+                                            }
+                                        }}
+                                        disabled={!this.props.gameState.canRefuseSupport(this.props.gameClient.authenticatedPlayer.house)}>
+                                        Refuse received support
+                                    </Button>
+                                </Col>}
+                            </Row>
                         </Col>
                     </>
                 )}

--- a/agot-bg-game-server/src/client/game-state-panel/DeclareSupportComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/DeclareSupportComponent.tsx
@@ -65,7 +65,7 @@ export default class DeclareSupportComponent extends Component<GameStateComponen
     }
 
     canChoose(supportedHouse: House): boolean {
-        return this.props.gameState.isRestrictedToHimself() ? supportedHouse == this.props.gameState.house : true;
+        return this.props.gameState.combatGameState.isRestrictedToHimself(supportedHouse) ? supportedHouse == this.props.gameState.house : true;
     }
 
     choose(house: House | null): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/declare-support-game-state/DeclareSupportGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/declare-support-game-state/DeclareSupportGameState.ts
@@ -41,34 +41,10 @@ export default class DeclareSupportGameState extends GameState<CombatGameState> 
 
             const supportedHouse = message.supportedHouseId ? this.game.houses.get(message.supportedHouseId) : null;
 
-            if (supportedHouse != null) {
-                if (this.isRestrictedToHimself() && supportedHouse != this.house) {
-                    return;
-                } else if (!this.combatGameState.houseCombatDatas.keys.includes(supportedHouse)) {
-                    return;
-                }
-            }
-
-            this.combatGameState.supporters.set(this.house, supportedHouse);
-
-            this.ingameGameState.log({
-                type: "support-declared",
-                supporter: player.house.id,
-                supported: supportedHouse ? supportedHouse.id : null
-            });
-
-            this.entireGame.broadcastToClients({
-                type: "support-declared",
-                houseId: this.house.id,
-                supportedHouseId: supportedHouse ? supportedHouse.id : null
-            });
+            this.combatGameState.declareSupport(this.house, supportedHouse, true);
 
             this.combatGameState.onDeclareSupportGameStateEnd();
         }
-    }
-
-    isRestrictedToHimself(): boolean {
-        return this.combatGameState.houseCombatDatas.keys.includes(this.house);
     }
 
     onServerMessage(message: ServerMessage): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -3,7 +3,7 @@ export default interface GameLog {
     data: GameLogData;
 }
 
-export type GameLogData = TurnBegin | SupportDeclared | Attack | MarchResolved
+export type GameLogData = TurnBegin | SupportDeclared | SupportRefused | Attack | MarchResolved
     | WesterosCardExecuted | WesterosCardDrawn | CombatResult | WildlingCardRevealed | WildlingBidding
     | HighestBidderChosen | LowestBidderChosen | PlayerMustered | WinnerDeclared
     | RavenHolderWildlingCardPutBottom | RavenHolderWildlingCardPutTop | RavenHolderReplaceOrder | RaidDone | DarkWingsDarkWordsChoice
@@ -39,6 +39,11 @@ interface SupportDeclared {
     type: "support-declared";
     supporter: string;
     supported: string | null;
+}
+
+interface SupportRefused {
+    type: "support-refused";
+    house: string;
 }
 
 interface HouseCardChosen {

--- a/agot-bg-game-server/src/messages/ClientMessage.ts
+++ b/agot-bg-game-server/src/messages/ClientMessage.ts
@@ -1,5 +1,5 @@
 export type ClientMessage = Ping | Authenticate | PlaceOrder | Ready | Unready | ResolveMarchOrder | DeclareSupport
-    | UseValyrianSteelBlade | ChooseHouseCard | ChooseCasualties | ChooseRavenAction | KickPlayer
+    | RefuseSupport | UseValyrianSteelBlade | ChooseHouseCard | ChooseCasualties | ChooseRavenAction | KickPlayer
     | ChooseTopWildlingCardAction | ReplaceOrder | SkipReplaceOrder | ResolveRaid | Bid | ChooseChoice
     | DecideBiggest | ReconcileArmies | Muster | ResolveTies | SelectUnits | LaunchGame | ChooseHouse
     | SelectOrders | SelectHouseCard | SelectRegion | ChangeSettings | CreatePrivateChatRoom | ChangeGameSettings
@@ -55,6 +55,10 @@ interface ResolveMarchOrder {
 interface DeclareSupport {
     type: "declare-support";
     supportedHouseId: string | null;
+}
+
+interface RefuseSupport {
+    type: "refuse-support";
 }
 
 interface UseValyrianSteelBlade {

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -9,7 +9,7 @@ import { SerializedWesterosCard } from "../common/ingame-game-state/game-data-st
 import { SerializedVote } from "../common/ingame-game-state/vote-system/Vote";
 
 export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | OrderPlaced | PlayerReady | PlayerUnready
-    | HouseCardChosen | CombatImmediatelyKilledUnits | SupportDeclared | NewTurn | RemovePlacedOrder
+    | HouseCardChosen | CombatImmediatelyKilledUnits | SupportDeclared | SupportRefused | NewTurn | RemovePlacedOrder
     | MoveUnits | CombatChangeArmy
     | UnitsWounded | ChangeCombatHouseCard | BeginSeeTopWildlingCard
     | RavenOrderReplaced | RevealTopWildlingCard | HideTopWildlingCard | ProceedWesterosCard | ChangeGarrison
@@ -66,6 +66,11 @@ interface SupportDeclared {
     type: "support-declared";
     houseId: string;
     supportedHouseId: string | null;
+}
+
+interface SupportRefused {
+    type: "support-refused";
+    houseId: string;
 }
 
 interface HouseCardChosen {


### PR DESCRIPTION
Closes #407 
Closes #362 


Preview of the new ChooseHouseCardComponent:

![image](https://user-images.githubusercontent.com/22304202/89208205-37812580-d5bc-11ea-84b1-34344a58916b.png)
