### PR TITLE
Make unit upgrades maintain previous wounded status

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -148,17 +148,6 @@ export default class IngameGameState extends GameState<
         return originalValue - house.powerTokens;
     }
 
-    transformSingle(unit: Unit, targetType: UnitType): Unit {
-        unit.region.units.delete(unit.id);
-
-        const newUnit = this.game.createUnit(unit.region, targetType, unit.allegiance);
-        newUnit.region.units.set(newUnit.id, newUnit);
-
-        newUnit.wounded = unit.wounded;
-
-        return newUnit
-    }
-
     transformUnits(region: Region, units: Unit[], targetType: UnitType): Unit[] {
         this.entireGame.broadcastToClients({
             type: "remove-units",
@@ -166,7 +155,16 @@ export default class IngameGameState extends GameState<
             unitIds: units.map(u => u.id)
         });
 
-        const transformed = units.map(u => this.transformSingle(u, targetType));
+        const transformed = units.map(unit => {
+            unit.region.units.delete(unit.id);
+
+            const newUnit = this.game.createUnit(unit.region, targetType, unit.allegiance);
+            newUnit.region.units.set(newUnit.id, newUnit);
+
+            newUnit.wounded = unit.wounded;
+
+            return newUnit;
+        });
 
         this.entireGame.broadcastToClients({
             type: "add-units",

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
@@ -110,8 +110,14 @@ export default class RenlyBaratheonAbilityGameState extends GameState<
                 unitIds: footmenToRemove.map(k => k.id)
             });
 
-            // Replace them by footman
-            const knightsToAdd = footmenToRemove.map(_ => this.game.createUnit(region, knight, house));
+            // Replace them by knight
+            const knightsToAdd = footmenToRemove.map(footman => {
+                const newKnight = this.game.createUnit(region, knight, house);
+                newKnight.wounded = footman.wounded;
+
+                return newKnight
+            });
+
             if (houseCombatData.region == region) {
                 // If the new knight is part of the attacking army,
                 // it will now be part of the army

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
@@ -88,7 +88,7 @@ export default class RenlyBaratheonAbilityGameState extends GameState<
 
         selectedUnit.forEach(([region, footmenToRemove]) => {
             // Replace them by knight
-            const knightsToAdd = this.game.transformUnits(region, footmenToRemove, knight, this.entireGame);
+            const knightsToAdd = this.ingame.transformUnits(region, footmenToRemove, knight);
 
             if (houseCombatData.region == region) {
                 // In case the footman was party of the army,

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
@@ -87,26 +87,24 @@ export default class RenlyBaratheonAbilityGameState extends GameState<
         const houseCombatData = this.combatGameState.houseCombatDatas.get(house);
 
         selectedUnit.forEach(([region, footmenToRemove]) => {
+            // Replace them by knight
+            const knightsToAdd = this.game.transformUnits(region, footmenToRemove, knight, this.entireGame);
+
             if (houseCombatData.region == region) {
                 // In case the footman was party of the army,
                 // remove it from the army.
                 houseCombatData.army = _.without(houseCombatData.army, ...footmenToRemove);
 
+                // If the new knight is part of the attacking army,
+                // it will now be part of the army
+                houseCombatData.army.push(...knightsToAdd);
+
                 this.entireGame.broadcastToClients({
                     type: "combat-change-army",
                     house: house.id,
                     region: region.id,
-                    army: this.combatGameState.houseCombatDatas.get(house).army.map(u => u.id)
+                    army: houseCombatData.army.map(u => u.id)
                 });
-            }
-
-            // Replace them by knight
-            const knightsToAdd = this.game.transformUnits(region, footmenToRemove, knight, this.entireGame);
-
-            if (houseCombatData.region == region) {
-                // If the new knight is part of the attacking army,
-                // it will now be part of the army
-                houseCombatData.army.push(...knightsToAdd);
             }
 
             this.ingame.log({

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -149,23 +149,25 @@ export default class Game {
         return unit;
     }
 
-    transformUnits(region: Region, units: Unit[], targetType: UnitType, entireGame: EntireGame): Unit[] {
-        units.forEach(u => u.region.units.delete(u.id));
+    transformSingle(unit: Unit, targetType: UnitType): Unit {
+        unit.region.units.delete(unit.id);
 
+        const newUnit = this.createUnit(unit.region, targetType, unit.allegiance);
+        newUnit.region.units.set(newUnit.id, newUnit);
+
+        newUnit.wounded = unit.wounded;
+
+        return newUnit
+    }
+
+    transformUnits(region: Region, units: Unit[], targetType: UnitType, entireGame: EntireGame): Unit[] {
         entireGame.broadcastToClients({
             type: "remove-units",
             regionId: region.id,
             unitIds: units.map(u => u.id)
         });
 
-        const transformed = units.map(u => {
-            const t = this.createUnit(u.region, targetType, u.allegiance);
-            t.region.units.set(t.id, t);
-
-            t.wounded = u.wounded;
-
-            return t;
-        });
+        const transformed = units.map(u => this.transformSingle(u, targetType));
 
         entireGame.broadcastToClients({
             type: "add-units",

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -149,34 +149,6 @@ export default class Game {
         return unit;
     }
 
-    transformSingle(unit: Unit, targetType: UnitType): Unit {
-        unit.region.units.delete(unit.id);
-
-        const newUnit = this.createUnit(unit.region, targetType, unit.allegiance);
-        newUnit.region.units.set(newUnit.id, newUnit);
-
-        newUnit.wounded = unit.wounded;
-
-        return newUnit
-    }
-
-    transformUnits(region: Region, units: Unit[], targetType: UnitType, entireGame: EntireGame): Unit[] {
-        entireGame.broadcastToClients({
-            type: "remove-units",
-            regionId: region.id,
-            unitIds: units.map(u => u.id)
-        });
-
-        const transformed = units.map(u => this.transformSingle(u, targetType));
-
-        entireGame.broadcastToClients({
-            type: "add-units",
-            units: [[region.id, transformed.map(u => u.serializeToClient())]]
-        });
-
-        return transformed;
-    }
-
     getControlledSupplyIcons(house: House): number {
         return _.sum(
             this.world.regions.values

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
@@ -62,6 +62,10 @@ export default class PlayerMusteringGameState extends GameState<ParentGameState>
         return this.parentGameState as ResolveConsolidatePowerGameState;
     }
 
+    get ingame(): IngameGameState {
+        return this.parentGameState.ingame;
+    }
+
     firstStart(house: House, type: PlayerMusteringType): void {
         this.house = house;
         this.type = type;
@@ -151,7 +155,7 @@ export default class PlayerMusteringGameState extends GameState<ParentGameState>
                         }
                         totalRemovedUnits.get(region).push(from);
 
-                        unit = this.game.transformSingle(from, to);
+                        unit = this.ingame.transformSingle(from, to);
                     } else {
                         unit = this.game.createUnit(region, to, this.house);
                         region.units.set(unit.id, unit);

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
@@ -144,21 +144,22 @@ export default class PlayerMusteringGameState extends GameState<ParentGameState>
             // Remove units that will be used to upgrade, and add mustered units
             musterings.entries.forEach(([_, recruitements]) => {
                 recruitements.forEach(({from, to, region}) => {
+                    let unit: Unit;
                     if (from) {
                         if (!totalRemovedUnits.has(region)) {
                             totalRemovedUnits.set(region, []);
                         }
-
-                        region.units.delete(from.id);
                         totalRemovedUnits.get(region).push(from);
+
+                        unit = this.game.transformSingle(from, to);
+                    } else {
+                        unit = this.game.createUnit(region, to, this.house);
+                        region.units.set(unit.id, unit);
                     }
 
                     if (!totalAddedUnits.has(region)) {
                         totalAddedUnits.set(region, []);
                     }
-
-                    const unit = this.game.createUnit(region, to, this.house);
-                    region.units.set(unit.id, unit);
                     totalAddedUnits.get(region).push(unit);
                 });
             });

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
@@ -62,7 +62,7 @@ export default class CrowKillersNightsWatchVictoryGameState extends GameState<Wi
 
     onSelectUnitsEnd(house: House, selectedUnits: [Region, Unit[]][]): void {
         selectedUnits.forEach(([region, footmen]) => {
-            this.transformIntoKnight(house, region, footmen);
+            this.game.transformUnits(region, footmen, knight, this.entireGame);
         });
 
         this.ingame.log({
@@ -72,26 +72,6 @@ export default class CrowKillersNightsWatchVictoryGameState extends GameState<Wi
         });
 
         this.parentGameState.onWildlingCardExecuteEnd();
-    }
-
-    transformIntoKnight(house: House, region: Region, footmenToRemove: Unit[]): void {
-        footmenToRemove.forEach(u => region.units.delete(u.id));
-
-        this.entireGame.broadcastToClients({
-            type: "remove-units",
-            regionId: region.id,
-            unitIds: footmenToRemove.map(k => k.id)
-        });
-
-        // Replace them by footman
-        const knightsToAdd = footmenToRemove.map(_ => this.game.createUnit(region, knight, house));
-
-        knightsToAdd.forEach(u => region.units.set(u.id, u));
-
-        this.entireGame.broadcastToClients({
-            type: "add-units",
-            units: [[region.id, knightsToAdd.map(u => u.serializeToClient())]]
-        });
     }
 
     onPlayerMessage(player: Player, message: ClientMessage): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-nights-watch-victory-game-state/CrowKillersNightsWatchVictoryGameState.ts
@@ -62,7 +62,7 @@ export default class CrowKillersNightsWatchVictoryGameState extends GameState<Wi
 
     onSelectUnitsEnd(house: House, selectedUnits: [Region, Unit[]][]): void {
         selectedUnits.forEach(([region, footmen]) => {
-            this.game.transformUnits(region, footmen, knight, this.entireGame);
+            this.ingame.transformUnits(region, footmen, knight);
         });
 
         this.ingame.log({

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
@@ -60,7 +60,7 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
     }
 
     transformSelection(house: House, selectedUnits: [Region, Unit[]][]): void {
-        selectedUnits.forEach(([region, knights]) => this.game.transformUnits(region, knights, footman, this.entireGame));
+        selectedUnits.forEach(([region, knights]) => this.ingame.transformUnits(region, knights, footman));
 
         this.ingame.log({
             type: "crow-killers-knights-replaced",


### PR DESCRIPTION
Fixes #479 

Allow Renly Baratheon's ability to maintain the upgraded footman's wounded status.
This is done through adding `transformUnits` and `transformSingle` to `Game`, in order to reduce code duplication whenever unit transformations happens. Changes to accomodate the use of these methods in the appropriate contexts are also done in Crow Killers' effects, and mustering.

If a more minimal version that only fixes Renly's bug is wanted without changes in the rest of the code, only the first commit should be merged.