### PR TITLE
Fix 2nd wildlings attack after Preemptive Raid

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/BiddingComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/BiddingComponent.tsx
@@ -33,7 +33,7 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
     render(): ReactNode {
         return (
             <>
-                {this.props.gameClient.authenticatedPlayer && (
+                {this.props.gameClient.authenticatedPlayer && this.props.gameState.participatingHouses.includes(this.props.gameClient.authenticatedPlayer.house) && (
                     <>
                         <Col xs={12}>
                             <Row className="justify-content-center">

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/wildling-card/PreemptiveRaidWildlingCardType.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/wildling-card/PreemptiveRaidWildlingCardType.ts
@@ -9,6 +9,12 @@ export default class PreemptiveRaidWildlingCardType extends WildlingCardType {
     executeNightsWatchWon(wildlingsAttack: WildlingsAttackGameState): void {
         const wildlingStrength = 6;
 
+        wildlingsAttack.game.wildlingStrength = wildlingStrength;
+        wildlingsAttack.entireGame.broadcastToClients({
+            type: "change-wildling-strength",
+            wildlingStrength: wildlingStrength
+        });
+
         wildlingsAttack.ingame.log({
             type: "preemptive-raid-wildlings-attack",
             house: wildlingsAttack.highestBidder.id,


### PR DESCRIPTION
Closes #483 

Note: Moving the initialization of the bids map into firstStart() doesn't solve a minor UX issue: The old given bid is still preselected on the 2nd wildlings attack (in a live game, in a pbem it won't happen). Due to lack of time I had no chance to fix it completely but I wanted to PR it already so it can be reviewed and eventually merged with this limitation which could be solved in a later PR. Or if you have an idea what is missing please comment it here. I will add it this evening.