### PR TITLE
Change cards to be discarded right before After Combat Game State

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
@@ -97,9 +97,6 @@ export default class PostCombatGameState extends GameState<
             });
         }
 
-        // Put the house cards as used
-        this.combat.houseCombatDatas.forEach(({houseCard}, house) => this.markHouseAsUsed(house, houseCard));
-
         this.setChildGameState(new AfterWinnerDeterminationGameState(this)).firstStart();
     }
 
@@ -243,6 +240,9 @@ export default class PostCombatGameState extends GameState<
 
         // Remove the order from attacking region
         this.removeOrderFromRegion(this.combat.attackingRegion);
+
+        // Put the house cards as used
+        this.combat.houseCombatDatas.forEach(({houseCard}, house) => this.markHouseAsUsed(house, houseCard));
 
         this.setChildGameState(new AfterCombatHouseCardAbilitiesGameState(this)).firstStart();
     }


### PR DESCRIPTION
Fixes #500 

When Davos is the last card in hand, he doesn't get his sword icon properly since the house card hand is reset before casualties from sword icons are dealt. This PR moves the house card discards (and hand resets) to happen near the end of the combat, right before After Combat abilities are triggered.