### PR TITLE
Add pillaging results to raid game log

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -294,15 +294,23 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 // Those 3 variables will always be all null or all non-null
                 if (raidee && raidedRegion && orderRaided) {
                     return (
-                        <p>
-                            <strong>{raider.name}</strong> raided <strong>{raidee.name}</strong>&apos;s <strong>{orderRaided.type.name}
-                            </strong> in <strong>{raidedRegion.name}</strong> from <strong>{raiderRegion.name}</strong>
-                        </p>
+                        <>
+                            <p>
+                                <strong>{raider.name}</strong> raided <strong>{raidee.name}</strong>&apos;s <strong>{orderRaided.type.name}
+                                </strong> in <strong>{raidedRegion.name}</strong> from <strong>{raiderRegion.name}</strong>.
+                            </p>
+                            {data.raiderGainedPowerToken &&
+                                <p><strong>{raider.name}</strong> gained {data.raiderGainedPowerToken ? "a" : "no"} Power Token
+                                    from this raid.</p>}
+                            {data.raidedHouseLostPowerToken != null
+                                && <p><strong>{raidee.name}</strong> lost {data.raidedHouseLostPowerToken ? "a" : "no"} Power Token
+                                    from this raid.</p>}
+                        </>
                     );
                 } else {
                     return (
                         <p>
-                            <strong>{raider.name}</strong> raided nothing from <strong>{raiderRegion.name}</strong>
+                            <strong>{raider.name}</strong> raided nothing from <strong>{raiderRegion.name}</strong>.
                         </p>
                     );
                 }

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
@@ -92,9 +92,12 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
                 throw new Error();
             }
 
+            let raiderGainedPowerToken: boolean | null = null;
+            let raidedHouseLostPowerToken: boolean | null = null;
+
             if (orderTarget.type instanceof ConsolidatePowerOrderType) {
-                this.ingameGameState.changePowerTokens(this.house, 1);
-                this.ingameGameState.changePowerTokens(raidedHouse, -1);
+                raiderGainedPowerToken = this.ingameGameState.changePowerTokens(this.house, 1) != 0;
+                raidedHouseLostPowerToken = this.ingameGameState.changePowerTokens(raidedHouse, -1) != 0;
             }
 
             this.actionGameState.ordersOnBoard.delete(targetRegion);
@@ -110,7 +113,9 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
                 raidee: raidedHouse.id,
                 raiderRegion: orderRegion.id,
                 raidedRegion: targetRegion.id,
-                orderRaided: orderTarget.id
+                orderRaided: orderTarget.id,
+                raiderGainedPowerToken: raiderGainedPowerToken,
+                raidedHouseLostPowerToken: raidedHouseLostPowerToken
             });
         } else {
             this.ingameGameState.log({
@@ -119,7 +124,9 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
                 raiderRegion: orderRegion.id,
                 raidedRegion: null,
                 raidee: null,
-                orderRaided: null
+                orderRaided: null,
+                raiderGainedPowerToken: null,
+                raidedHouseLostPowerToken: null
             });
         }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -151,6 +151,8 @@ interface RaidDone {
     raiderRegion: string;
     raidedRegion: string | null;
     orderRaided: number | null;
+    raiderGainedPowerToken: boolean | null;
+    raidedHouseLostPowerToken: boolean | null;
 }
 
 interface DarkWingsDarkWordsChoice {


### PR DESCRIPTION
Resolves a request from Tex on Discord which is not issued here yet. This also seems necessary if we want to replay a game by the game log entries.

Preview:

![image](https://user-images.githubusercontent.com/22304202/78857313-56661580-7a29-11ea-85ba-332bbde9d424.png)
