### PR TITLE
Add info whether Power Token was left to march game log

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -94,14 +94,16 @@ export default class GameLogListComponent extends Component<GameLogListComponent
 
                 return (
                     <>
-                        <b>{house.name}</b> marched from <b>{startingRegion.name}</b>:
+                        <b>{house.name}</b> marched from <b>{startingRegion.name}</b>{
+                            data.leftPowerToken != null && <> and left {data.leftPowerToken ? "a" : "no"} Power Token</>}{moves.length > 0 ? ":" : "."}
+                        {moves.length > 0 &&
                         <ul>
                             {moves.map(([region, unitTypes]) => (
                                 <li key={region.id}>
                                     {joinReactNodes(unitTypes.map((ut, i) => <b key={i}>{ut.name}</b>), ", ")} to <b>{region.name}</b>
                                 </li>
                             ))}
-                        </ul>
+                        </ul>}
                     </>
                 );
 

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -60,6 +60,7 @@ interface MarchResolved {
     house: string;
     startingRegion: string;
     moves: [string, string[]][];
+    leftPowerToken: boolean | null;
 }
 
 interface WesterosCardExecuted {


### PR DESCRIPTION
When doing the pillaging PR I thought it might be good to have the info of left Power Tokens also in the game log but that wasn't this easy to integrate. Problem is when you march from a sea region with all ships to attack an enemy. See my previews how I solved it. Please feel free to simply close this PR if you don't want to do it that way.

![image](https://user-images.githubusercontent.com/22304202/78861004-f32db080-7a33-11ea-9f85-a12e91164643.png)
![image](https://user-images.githubusercontent.com/22304202/78861039-1193ac00-7a34-11ea-9f94-717463251d86.png)
![image](https://user-images.githubusercontent.com/22304202/78861129-4bfd4900-7a34-11ea-913e-ca8d75ade6ea.png)
