### PR TITLE
Fix Tywin Lannister's game log messsage

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -145,7 +145,7 @@ export default class IngameGameState extends GameState<
             powerTokenCount: house.powerTokens
         });
 
-        return originalValue - house.powerTokens;
+        return house.powerTokens - originalValue;
     }
 
     transformUnits(region: Region, units: Unit[], targetType: UnitType): Unit[] {


### PR DESCRIPTION
Fixes #531 

This is done by reversing the sign of `changePowerTokens` return value so that it returns the delta proper (positive if increased, negative if decreased). As far as I could see, Tywin Lannister's ability was the only case in which the return value was used in the first place so this shouldn't harm anything else.