### PR TITLE
Add Power token tooltip

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -288,13 +288,19 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                                                 </Col>
                                                 <Col xs="auto" className="d-flex align-items-center">
                                                     <div style={{fontSize: "18px"}}>{p.house.powerTokens}</div>
-                                                    <div
-                                                        className="house-power-token hover-weak-outline"
-                                                        style={{
-                                                            backgroundImage: `url(${housePowerTokensImages.get(p.house.id)})`,
-                                                            marginLeft: "10px"
-                                                        }}
-                                                    />
+                                                    <OverlayTrigger
+                                                        overlay={this.renderPowerTooltip(p.house)}
+                                                        delay={{show: 750, hide: 100}}
+                                                        placement="auto"
+                                                    >
+                                                        <div
+                                                            className="house-power-token hover-weak-outline"
+                                                            style={{
+                                                                backgroundImage: `url(${housePowerTokensImages.get(p.house.id)})`,
+                                                                marginLeft: "10px"
+                                                            }}
+                                                        />
+                                                    </OverlayTrigger>
                                                 </Col>
                                             </Row>
                                             <Row className="justify-content-center">
@@ -465,6 +471,19 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     get publicChatRoom(): Channel {
         return this.props.gameClient.chatClient.channels.get(this.props.gameState.entireGame.publicChatRoomId);
+    }
+
+    private renderPowerTooltip(house: House): ReactNode {
+        const availablePower =  house.powerTokens;
+        const powerTokensOnBoard = this.game.countPowerTokensOnBoard(house);
+        const powerInPool = this.game.maxPowerTokens - availablePower - powerTokensOnBoard;
+
+        return <Tooltip id={house.id + "-power-tooltip"}>
+            <b>{house.name}</b><br/>
+            <small>Available: </small><b>{availablePower}</b><br/>
+            <small>On the board: </small><b>{powerTokensOnBoard}</b><br/>
+            <small>Power Pool: </small><b>{powerInPool}</b>
+        </Tooltip>;
     }
 
     onNewPrivateChatRoomClick(p: Player): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -21,8 +21,6 @@ import {GameLogData} from "./game-data-structure/GameLog";
 import GameEndedGameState, {SerializedGameEndedGameState} from "./game-ended-game-state/GameEndedGameState";
 import UnitType from "./game-data-structure/UnitType";
 
-const MAX_POWER_TOKENS = 20;
-
 export default class IngameGameState extends GameState<
     EntireGame,
     WesterosGameState | PlanningGameState | ActionGameState | GameEndedGameState
@@ -134,7 +132,7 @@ export default class IngameGameState extends GameState<
         const originalValue = house.powerTokens;
 
         const powerTokensOnBoardCount = this.game.countPowerTokensOnBoard(house);
-        const maxPowerTokenCount = MAX_POWER_TOKENS - powerTokensOnBoardCount;
+        const maxPowerTokenCount = this.game.maxPowerTokens - powerTokensOnBoardCount;
 
         house.powerTokens += delta;
         house.powerTokens = Math.max(0, Math.min(house.powerTokens, maxPowerTokenCount));

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -14,7 +14,6 @@ import BetterMap from "../../../utils/BetterMap";
 import HouseCard from "./house-card/HouseCard";
 import {land, port} from "./regionTypes";
 import PlanningRestriction from "./westeros-card/planning-restriction/PlanningRestriction";
-import EntireGame from "../../EntireGame";
 
 export const MAX_WILDLING_STRENGTH = 12;
 
@@ -36,6 +35,7 @@ export default class Game {
     skipRavenPhase: boolean;
     structuresCountNeededToWin: number;
     maxTurns: number;
+    maxPowerTokens: number;
 
     get ironThroneHolder(): House {
         return this.getTokenHolder(this.ironThroneTrack);
@@ -323,7 +323,8 @@ export default class Game {
             starredOrderRestrictions: this.starredOrderRestrictions,
             skipRavenPhase: this.skipRavenPhase,
             structuresCountNeededToWin: this.structuresCountNeededToWin,
-            maxTurns: this.maxTurns
+            maxTurns: this.maxTurns,
+            maxPowerTokens: this.maxPowerTokens
         };
     }
 
@@ -346,6 +347,7 @@ export default class Game {
         game.skipRavenPhase = data.skipRavenPhase;
         game.structuresCountNeededToWin = data.structuresCountNeededToWin;
         game.maxTurns = data.maxTurns;
+        game.maxPowerTokens = data.maxPowerTokens;
 
         return game;
     }
@@ -368,4 +370,5 @@ export interface SerializedGame {
     skipRavenPhase: boolean;
     structuresCountNeededToWin: number;
     maxTurns: number;
+    maxPowerTokens: number;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
@@ -18,6 +18,8 @@ import * as _ from "lodash";
 import houseCardAbilities from "./house-card/houseCardAbilities";
 import EntireGame from "../../EntireGame";
 
+const MAX_POWER_TOKENS = 20;
+
 interface TiledSquareObject {
     name: string;
     x: number;
@@ -125,6 +127,7 @@ export default function createGame(entireGame: EntireGame, housesToCreate: strin
     game.maxTurns = baseGameData.maxTurns;
     game.structuresCountNeededToWin = baseGameData.structuresCountNeededToWin;
     game.supplyRestrictions = baseGameData.supplyRestrictions;
+    game.maxPowerTokens = MAX_POWER_TOKENS;
 
     // Load tracks starting positions
     if (gameSetup.tracks && gameSetup.tracks.ironThrone) {

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -108,6 +108,16 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "4",
+        migrate: (serializedGame: any) => {
+            // Migration for #532
+            if (serializedGame.childGameState.type == "ingame") {
+                // Set max power tokens to the default max of 20
+                serializedGame.childGameState.game.maxPowerTokens = 20;
+            }
+        }
     }
 ];
 


### PR DESCRIPTION
Fixes #532 

Add a hover tooltip to the Power token symbol showing where the player's Power tokens are: available, on the board or in the Power Pool:
![image](https://user-images.githubusercontent.com/18612633/79101905-48d6c580-7d72-11ea-8ffc-7eeda7c470db.png)

The change is structured so that it moves `MAX_POWER_TOKENS` into an attribute of `Game` (and `SerializedGame`) similarly to other game constants, requiring a migration.