### PR TITLE
Improve wounded unit readability

### DIFF
--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -148,6 +148,22 @@ export default class MapComponent extends Component<MapComponentProps> {
                 {r.units.values.map(u => {
                     const property = propertiesForUnits.get(u);
 
+                    let opacity: number;
+                    // css transform
+                    let transform: string;
+
+                    if (!u.wounded) {
+                        opacity = 1;
+                        transform = ``;
+                    } else if (u.type.name == "Ship") {
+                        opacity = 0.5;
+                        transform = ``;
+                    } else {
+                        opacity = 0.7;
+                        transform = `rotate(90deg)`;
+                    }
+
+
                     return <div key={u.id}
                                 onClick={property.onClick ? property.onClick : undefined}
                                 className={classNames(
@@ -158,7 +174,8 @@ export default class MapComponent extends Component<MapComponentProps> {
                                 )}
                                 style={{
                                     backgroundImage: `url(${unitImages.get(u.allegiance.id).get(u.type.id)})`,
-                                    opacity: u.wounded ? 0.5 : 1
+                                    opacity: opacity,
+                                    transform: transform
                                 }}/>;
                 })}
             </div>


### PR DESCRIPTION
Partially solves #488

Changes from current display:
- Non-routed units: unchanged
- Routed ground units: turned 90 degrees clockwise, increased opacity to 0.7
- Routed ships: unchanged

Drive folder with images for all unit types of all different players:
https://drive.google.com/drive/folders/1Ab3_4o_pTue8wVkwA09JxuPuwZmvVM3j?usp=sharing

Ship display is still lackluster for now, but will be improved at a different time.