### PR TITLE
Fix an error in Mace Tyrell's Game Log

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -604,7 +604,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 house = this.game.houses.get(data.house);
 
                 return <>
-                    <strong>Mace Tyrell</strong>: Casualties were prevented by <strong>Robb Stark</strong>.
+                    <strong>Mace Tyrell</strong>: Casualties were prevented by <strong>The Blackfish</strong>.
                 </>;
 
             case "mace-tyrell-no-footman-available":


### PR DESCRIPTION
Make Mace Tyrell state The Blackfish as the reason for casualty prevention instead of Robb Stark