### PR TITLE
Add tooltips to the influence icons.

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -49,6 +49,7 @@ import Tab from "react-bootstrap/Tab";
 import ChatComponent from "./chat-client/ChatComponent";
 import {HouseCardState} from "../common/ingame-game-state/game-data-structure/house-card/HouseCard";
 import HouseCardBackComponent from "./game-state-panel/utils/HouseCardBackComponent";
+import InfluenceIconComponent from "./game-state-panel/utils/InfluenceIconComponent";
 import Dropdown from "react-bootstrap/Dropdown";
 import User from "../server/User";
 import Player from "../common/ingame-game-state/Player";
@@ -163,9 +164,9 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                                                 </Col>
                                                 {tracker.map((h, i) => (
                                                     <Col xs="auto" key={h.id}>
-                                                        <div className="influence-icon hover-weak-outline"
-                                                             style={{backgroundImage: `url(${houseInfluenceImages.get(h.id)})`}}>
-                                                        </div>
+                                                        <InfluenceIconComponent
+                                                            house={h}
+                                                        />
                                                         <div className="tracker-star-container">
                                                             {stars && i < this.game.starredOrderRestrictions.length && (
                                                                 _.range(0, this.game.starredOrderRestrictions[i]).map(i => (

--- a/agot-bg-game-server/src/client/game-state-panel/utils/InfluenceIconComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/InfluenceIconComponent.tsx
@@ -1,0 +1,29 @@
+import {Component, default as React, ReactNode} from "react";
+import {observer} from "mobx-react";
+import Tooltip from "react-bootstrap/Tooltip";
+import houseInfluenceImages from "../../houseInfluenceImages";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import House from "../../../common/ingame-game-state/game-data-structure/House";
+
+interface InfluenceIconComponentProps {
+    house: House;
+}
+
+@observer
+export default class InfluenceIconComponent extends Component<InfluenceIconComponentProps> {
+    render(): ReactNode {
+        return (
+            <OverlayTrigger overlay={
+                    <Tooltip id="influence-icon">
+                        <b>{this.props.house.name}</b>
+                    </Tooltip>
+                }
+                placement="bottom"
+            >
+                <div className="influence-icon hover-weak-outline"
+                    style={{backgroundImage: `url(${houseInfluenceImages.get(this.props.house.id)})`}}>
+                </div>
+            </OverlayTrigger>
+        );
+    }
+}


### PR DESCRIPTION
This also refactored the existing tooltips used for the
influence icons shown in the supply track.

Example: https://i.imgur.com/XG5sSPC.jpg