### PR TITLE
Fast-track Raid Resolution when only Raid Orders can be removed

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -315,6 +315,33 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                     );
                 }
 
+            case "raid-resolution-fast-track":
+                const removedOrders = data.removedOrders;
+
+                return (<>
+                    <p>Raid Orders could only remove other Raid Orders, skipping to March Resolution.</p>
+                    {
+                        removedOrders.map(([houseId, removedOrders]) => {
+                            const house = this.game.houses.get(houseId);
+
+                            return (<>
+                                <p><strong>{house.name}</strong> removed:</p>
+                                <ul>
+                                    {
+                                        removedOrders.map(([regionId, starred]) =>
+                                        {
+                                            const region = this.game.world.regions.get(regionId);
+
+                                            return <li key={regionId}><strong>{starred ? "Special " : ""}Raid</strong> Order at <strong>{region.name}</strong></li>;
+                                        })
+                                    }
+                                </ul>
+                            </>);
+                        })
+                    }
+                    </>);
+
+
             case "a-throne-of-blades-choice":
                 house = this.game.houses.get(data.house);
 

--- a/agot-bg-game-server/src/client/game-state-panel/ResolveSingleRaidOrderComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveSingleRaidOrderComponent.tsx
@@ -112,7 +112,7 @@ export default class ResolveSingleRaidOrderComponent extends Component<GameState
                 ])
             } else {
                 // Highlight the possible raidable orders from the select Raid order
-                return this.props.gameState.getRaidableRegions(this.selectedOrderRegion, this.orderInOrderRegion).map(r => [
+                return this.props.gameState.parentGameState.getRaidableRegions(this.selectedOrderRegion, this.orderInOrderRegion).map(r => [
                     r,
                     {highlight: {active: true}, onClick: () => this.onOrderClick(r)}
                 ])

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
@@ -98,11 +98,15 @@ export default class ActionGameState extends GameState<IngameGameState, UseRaven
             .filter(([region, _order]) => region.getController() == house);
     }
 
-    getRegionsWithRaidOrderOfHouse(house: House): Region[] {
+    getAllRegionsWithRaidOrder(): Region[] {
         return this.ordersOnBoard.entries
-            .filter(([region, _order]) => region.getController() == house)
             .filter(([_region, order]) => order.type instanceof RaidOrderType)
             .map(([region, _order]) => region);
+    }
+
+    getRegionsWithRaidOrderOfHouse(house: House): Region[] {
+        return this.getAllRegionsWithRaidOrder()
+            .filter((region) => region.getController() == house);
     }
 
     getRegionsWithMarchOrderOfHouse(house: House): Region[] {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
@@ -46,7 +46,7 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
 
         // Check if all raid orders can not be trivially resolved
         const regionsWithRaidOrders = this.getRegionWithRaidOrders();
-        if (regionsWithRaidOrders.every(r => this.getRaidableRegions(r, this.actionGameState.ordersOnBoard.get(r).type as RaidOrderType).length == 0)) {
+        if (regionsWithRaidOrders.every(r => this.parentGameState.getRaidableRegions(r, this.actionGameState.ordersOnBoard.get(r).type as RaidOrderType).length == 0)) {
             // If yes, fast-track the game by resolving one
             const regionToResolve = regionsWithRaidOrders[0];
 
@@ -81,7 +81,7 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
         if (targetRegion) {
             const orderTarget = this.actionGameState.ordersOnBoard.get(targetRegion);
 
-            if (!this.getRaidableRegions(orderRegion, orderType).includes(targetRegion)) {
+            if (!this.parentGameState.getRaidableRegions(orderRegion, orderType).includes(targetRegion)) {
                 return;
             }
 
@@ -150,14 +150,6 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
 
     onServerMessage(_message: ServerMessage): void {
 
-    }
-
-    getRaidableRegions(orderRegion: Region, raid: RaidOrderType): Region[] {
-        return this.world.getNeighbouringRegions(orderRegion)
-            .filter(r => r.getController() != this.house)
-            .filter(r => this.actionGameState.ordersOnBoard.has(r))
-            .filter(r => raid.isValidRaidableOrder(this.actionGameState.ordersOnBoard.get(r)))
-            .filter(r => r.type.kind == orderRegion.type.kind || orderRegion.type.canAdditionalyRaid == r.type.kind);
     }
 
     resolveRaid(orderRegion: Region, targetRegion: Region | null): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -6,8 +6,8 @@ export default interface GameLog {
 export type GameLogData = TurnBegin | SupportDeclared | Attack | MarchResolved
     | WesterosCardExecuted | WesterosCardDrawn | CombatResult | WildlingCardRevealed | WildlingBidding
     | HighestBidderChosen | LowestBidderChosen | PlayerMustered | WinnerDeclared
-    | RavenHolderWildlingCardPutBottom | RavenHolderWildlingCardPutTop | RavenHolderReplaceOrder | RaidDone | DarkWingsDarkWordsChoice
-    | PutToTheSwordChoice | AThroneOfBladesChoice | WinterIsComing | WesterosPhaseBegan
+    | RavenHolderWildlingCardPutBottom | RavenHolderWildlingCardPutTop | RavenHolderReplaceOrder | RaidDone | RaidResolutionFastTrack
+    | DarkWingsDarkWordsChoice | PutToTheSwordChoice | AThroneOfBladesChoice | WinterIsComing | WesterosPhaseBegan
     | CombatHouseCardChosen | CombatValyrianSwordUsed | ClashOfKingsBiddingDone | ClashOfKingsFinalOrdering
     | ActionPhaseBegan | PlanningPhaseBegan | WildlingStrengthTriggerWildlingsAttack | MarchOrderRemoved
     | ConsolidatePowerOrderResolved | ArmiesReconciled | EnemyPortTaken | ShipsDestroyedByEmptyCastle
@@ -153,6 +153,12 @@ interface RaidDone {
     orderRaided: number | null;
     raiderGainedPowerToken: boolean | null;
     raidedHouseLostPowerToken: boolean | null;
+}
+
+interface RaidResolutionFastTrack {
+    type: "raid-resolution-fast-track";
+    // House id: (region id, starred)[]
+    removedOrders: [string, [string, boolean][]][];
 }
 
 interface DarkWingsDarkWordsChoice {


### PR DESCRIPTION
Closes #551 
When only Raid orders can be removed by **all** remaining Raids, resolution can be fast-tracked as the end result would just be the removal of all raids off the map. 