### PR TITLE
Improve bidding and send own bids to users

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/BiddingComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/BiddingComponent.tsx
@@ -7,33 +7,40 @@ import GameStateComponentProps from "./GameStateComponentProps";
 import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import Player from "../../common/ingame-game-state/Player";
 
 @observer
 export default class BiddingComponent<ParentGameState extends BiddingGameStateParent> extends Component<GameStateComponentProps<BiddingGameState<ParentGameState>>> {
     @observable powerTokensToBid = 0;
-    @observable dirty: boolean;
+
+    get gameState(): BiddingGameState<ParentGameState> {
+        return this.props.gameState;
+    }
+
+    get authenticatedPlayer(): Player | null {
+        return this.props.gameClient.authenticatedPlayer;
+    }
+
+    get biddenPowerTokens(): number {
+        return this.authenticatedPlayer
+            ? this.gameState.bids.tryGet(this.authenticatedPlayer.house, -1)
+            : -1;
+    }
+
+    get dirty(): boolean {
+        return this.powerTokensToBid != this.biddenPowerTokens;
+    }
 
     constructor(props: GameStateComponentProps<BiddingGameState<ParentGameState>>) {
         super(props);
 
-        const authenticatedPlayer = this.props.gameClient.authenticatedPlayer;
-
-        this.powerTokensToBid = authenticatedPlayer
-            ? this.props.gameState.hasBid(authenticatedPlayer.house)
-                ? this.props.gameState.bids.get(authenticatedPlayer.house)
-                : 0
-            : 0;
-        this.dirty = authenticatedPlayer
-            ? this.props.gameState.hasBid(authenticatedPlayer.house)
-                ? false
-                : true
-            :  false;
+        this.powerTokensToBid = Math.max(this.biddenPowerTokens, 0);
     }
 
     render(): ReactNode {
         return (
             <>
-                {this.props.gameClient.authenticatedPlayer && this.props.gameState.participatingHouses.includes(this.props.gameClient.authenticatedPlayer.house) && (
+                {this.authenticatedPlayer && this.gameState.participatingHouses.includes(this.authenticatedPlayer.house) && (
                     <>
                         <Col xs={12}>
                             <Row className="justify-content-center">
@@ -42,10 +49,10 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
                                         type="range"
                                         className="custom-range"
                                         min={0}
-                                        max={this.props.gameClient.authenticatedPlayer.house.powerTokens}
+                                        max={this.authenticatedPlayer.house.powerTokens}
                                         value={this.powerTokensToBid}
                                         onChange={e => this.changePowerTokensToBid(parseInt(e.target.value))}
-                                        disabled={!this.dirty && this.props.gameClient.authenticatedPlayer.house.powerTokens==0}
+                                        disabled={this.authenticatedPlayer.house.powerTokens==0}
                                     />
                                 </Col>
                                 <Col xs="auto">
@@ -66,7 +73,7 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
                     </>
                 )}
                 <Col xs={12} className="text-center">
-                    Waiting for {this.props.gameState.getHousesLeftToBid().map(h => h.name).join(", ")}
+                    Waiting for {this.gameState.getHousesLeftToBid().map(h => h.name).join(", ")}
                 </Col>
             </>
         );
@@ -74,11 +81,9 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
 
     changePowerTokensToBid(count: number): void {
         this.powerTokensToBid = count;
-        this.dirty = true;
     }
 
     bid(powerTokens: number): void {
-        this.props.gameState.bid(powerTokens);
-        this.dirty = false;
+        this.gameState.bid(powerTokens);
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/bidding-game-state/BiddingGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/bidding-game-state/BiddingGameState.ts
@@ -34,9 +34,17 @@ export default class BiddingGameState<ParentGameState extends BiddingGameStatePa
             const bid = Math.max(0, Math.min(message.powerTokens, player.house.powerTokens));
             this.bids.set(player.house, bid);
 
-            this.entireGame.broadcastToClients({
+            const otherHouses = _.difference(this.game.houses.values, [player.house]);
+            this.entireGame.sendMessageToClients(otherHouses.map(h => this.parentGameState.ingame.getControllerOfHouse(h).user), {
                 type: "bid-done",
-                houseId: player.house.id
+                houseId: player.house.id,
+                value: -1
+            });
+
+            this.entireGame.sendMessageToClients([player.user], {
+                type: "bid-done",
+                houseId: player.house.id,
+                value: bid
             });
 
             this.checkAndProceedEndOfBidding();
@@ -77,7 +85,7 @@ export default class BiddingGameState<ParentGameState extends BiddingGameStatePa
     onServerMessage(message: ServerMessage): void {
         if (message.type == "bid-done") {
             const house = this.game.houses.get(message.houseId);
-            this.bids.set(house, -1);
+            this.bids.set(house, message.value);
         }
     }
 

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -146,6 +146,7 @@ interface ProceedWesterosCard {
 interface BidDone {
     type: "bid-done";
     houseId: string;
+    value: number;
 }
 
 interface GameStateChange {


### PR DESCRIPTION
This PR follows the same way like `ChooseHouseCardGameState` does atm and `dirty` is now no field anymore but a property which compares the already given bid with the actual value of the slider. To make this work for live games also, `bid-done` now sends the given value to the user and -1 to all others.

Note: You wanted to apply a GUID to all states which will enforce the components to always reload on state change. E.g. in case of a second wildlings attack due to Preemptive Raid the old given value of the first wildlings attack will still be pre-selected.