### PR TITLE
Add tooltips to the Supply Track icon and each column.

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -23,8 +23,6 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faStar} from "@fortawesome/free-solid-svg-icons/faStar";
 import Tooltip from "react-bootstrap/Tooltip";
-import Badge from "react-bootstrap/Badge";
-import barrelImage from "../../public/images/icons/barrel.svg";
 import castleImage from "../../public/images/icons/castle.svg";
 import stoneThroneImage from "../../public/images/icons/stone-throne.svg";
 import ravenImage from "../../public/images/icons/raven.svg";
@@ -50,6 +48,7 @@ import ChatComponent from "./chat-client/ChatComponent";
 import {HouseCardState} from "../common/ingame-game-state/game-data-structure/house-card/HouseCard";
 import HouseCardBackComponent from "./game-state-panel/utils/HouseCardBackComponent";
 import InfluenceIconComponent from "./game-state-panel/utils/InfluenceIconComponent";
+import SupplyTrackComponent from "./game-state-panel/utils/SupplyTrackComponent";
 import Dropdown from "react-bootstrap/Dropdown";
 import User from "../server/User";
 import Player from "../common/ingame-game-state/Player";
@@ -184,56 +183,10 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                                         </ListGroupItem>
                                     ))}
                                     <ListGroupItem>
-                                        <Row>
-                                            <Col xs="auto">
-                                                <img width="32px" src={barrelImage} alt="Supply"/>
-                                            </Col>
-                                            <Col>
-                                                <Row className="justify-content-center">
-                                                    {this.game.supplyRestrictions.map((allowedArmies, i) => (
-                                                        <Col xs="auto" key={i} className="d-flex flex-column align-items-center">
-                                                            <div>
-                                                            <Badge variant="secondary" style={{fontSize: "14px"}}>
-                                                                {i}
-                                                            </Badge>
-                                                            </div>
-                                                            <div className="d-flex">
-                                                                <div style={{width: "18px", marginRight: "6px", marginTop: "10px"}}>
-                                                                    {this.getHousesAtSupplyLevel(i).map(h => (
-                                                                        <OverlayTrigger
-                                                                            key={h.id}
-                                                                            overlay={
-                                                                                <Tooltip id={`supply-house-${h.id}`}>
-                                                                                    {h.name}
-                                                                                </Tooltip>
-                                                                            }
-                                                                            placement="right">
-                                                                            <div
-                                                                                key={h.id}
-                                                                                className="supply-icon hover-weak-outline"
-                                                                                style={{
-                                                                                    backgroundImage: `url(${houseInfluenceImages.get(h.id)})`,
-                                                                                    marginTop: "-5px"
-                                                                                }}
-                                                                            >
-
-                                                                            </div>
-                                                                        </OverlayTrigger>
-                                                                    ))}
-                                                                </div>
-                                                                <div>
-                                                                    {allowedArmies.map((size, i) => (
-                                                                        <div style={{marginBottom: "-6px"}} key={i}>
-                                                                            {size}
-                                                                        </div>
-                                                                    ))}
-                                                                </div>
-                                                            </div>
-                                                        </Col>
-                                                    ))}
-                                                </Row>
-                                            </Col>
-                                        </Row>
+                                        <SupplyTrackComponent
+                                            supplyRestrictions={this.game.supplyRestrictions}
+                                            houses={this.game.houses}
+                                        />
                                     </ListGroupItem>
                                 </ListGroup>
                             </Card>
@@ -496,10 +449,6 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     getOtherPlayers(): Player[] {
         return this.props.gameState.players.values.filter(p => p.user != this.props.gameClient.authenticatedUser);
-    }
-
-    getHousesAtSupplyLevel(supplyLevel: number): House[] {
-        return this.game.houses.values.filter(h => h.supplyLevel == supplyLevel);
     }
 
     compileGameLog(gameLog: string): string {

--- a/agot-bg-game-server/src/client/game-state-panel/utils/SupplyTrackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/SupplyTrackComponent.tsx
@@ -24,12 +24,12 @@ export default class SupplyTrackComponent extends Component<SupplyTrackComponent
                     <OverlayTrigger overlay={
                         <Tooltip id="supply-track">
                             <b>Supply Track</b><br />
-                            Each column of the supply track contains a vertical list of numbers. These
-                            numbers describe the maximum size and count of each player's armies. (An army
-                            is defined as two or more friendly units in the same land or sea area.)<br />
-                            The supply track is updated when resolving the "Supply" Westeros card or from
-                            other game effects. The updated supply track position is determined by counting
-                            the number of Supply icons printed in areas that the player controls.
+                            Each supply track column contains a list of numbers illustrating the
+                            maximum size and count of each player's armies. (An army is made up
+                            of two or more units within the same land or sea area.) The supply
+                            track is updated from game effects, such as the "Supply" Westeros
+                            card. The updated supply position is determined by the number of
+                            Supply icons printed in areas that the player controls.
                         </Tooltip>
                         }
                         placement="right"

--- a/agot-bg-game-server/src/client/game-state-panel/utils/SupplyTrackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/SupplyTrackComponent.tsx
@@ -1,0 +1,136 @@
+import {Component, default as React, ReactNode} from "react";
+import {observer} from "mobx-react";
+import Badge from "react-bootstrap/Badge";
+import Col from "react-bootstrap/Col";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Row from "react-bootstrap/Row";
+import Tooltip from "react-bootstrap/Tooltip";
+import houseInfluenceImages from "../../houseInfluenceImages";
+import House from "../../../common/ingame-game-state/game-data-structure/House";
+import BetterMap from "../../../utils/BetterMap";
+import barrelImage from "../../../../public/images/icons/barrel.svg";
+
+interface SupplyTrackComponentProps {
+    supplyRestrictions: number[][];
+    houses: BetterMap<string, House>;
+}
+
+@observer
+export default class SupplyTrackComponent extends Component<SupplyTrackComponentProps> {
+    render(): ReactNode {
+        return (
+            <Row>
+                <Col xs="auto">
+                    <OverlayTrigger overlay={
+                        <Tooltip id="supply-track">
+                            <b>Supply Track</b><br />
+                            Each column of the supply track contains a vertical list of numbers. These
+                            numbers describe the maximum size and count of each player's armies. (An army
+                            is defined as two or more friendly units in the same land or sea area.)<br />
+                            The supply track is updated when resolving the "Supply" Westeros card or from
+                            other game effects. The updated supply track position is determined by counting
+                            the number of Supply icons printed in areas that the player controls.
+                        </Tooltip>
+                        }
+                        placement="right"
+                    >
+                        <img width="32px" src={barrelImage} alt="Supply"/>
+                    </OverlayTrigger>
+                </Col>
+                <Col>
+                    <Row className="justify-content-center">
+                        {this.props.supplyRestrictions.map((allowedArmies, i) => (
+                            <Col xs="auto" key={i} className="d-flex flex-column align-items-center">
+                                <div>
+                                    <OverlayTrigger
+                                        overlay={
+                                            <Tooltip id={`supply-track-col-${i}`}>
+                                                {i == 0 ? (
+                                                    <>
+                                                        Players may have two armies with a maximum size of 2 units each.
+                                                    </>
+                                                ) : i == 1 ? (
+                                                    <>
+                                                        Players may have two armies. One with a maximum size of 3 units
+                                                        and another with a maximum size of 2 units.
+                                                    </>
+                                                ) : i == 2 ? (
+                                                    <>
+                                                        Players may have three armies. One with a maximum size of 3 units
+                                                        and two others with a maximum size of 2 units each.
+                                                    </>
+                                                ) : i == 3 ? (
+                                                    <>
+                                                        Players may have four armies. One with a maximum size of 3 units
+                                                        and three others with a maximum size of 2 units each.
+                                                    </>
+                                                ) : i == 4 ? (
+                                                    <>
+                                                        Players may have four armies. Two with a maximum size of 3 units
+                                                        each and two others with a maximum size of 2 units each.
+                                                    </>
+                                                ) : i == 5 ? (
+                                                    <>
+                                                        Players may have four armies. One with a maximum size of 4 units,
+                                                        another with a maximum size of 3 units, and two others with a
+                                                        maximum size of 2 units each.
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        Players may have five armies. One with a maximum size of 4 units,
+                                                        another with a maximum size of 3 units, and three others with a
+                                                        maximum size of 2 units each.
+                                                    </>
+                                                )}
+                                            </Tooltip>
+                                        }
+                                        placement="right"
+                                    >
+                                        <Badge variant="secondary" style={{fontSize: "14px"}}>
+                                            {i}
+                                        </Badge>
+                                    </OverlayTrigger>
+                                </div>
+                                <div className="d-flex">
+                                    <div style={{width: "18px", marginRight: "6px", marginTop: "10px"}}>
+                                        {this.getHousesAtSupplyLevel(i).map(h => (
+                                            <OverlayTrigger
+                                                key={h.id}
+                                                overlay={
+                                                    <Tooltip id={`supply-house-${h.id}`}>
+                                                        {h.name}
+                                                    </Tooltip>
+                                                }
+                                                placement="right">
+                                                    <div
+                                                        key={h.id}
+                                                        className="supply-icon hover-weak-outline"
+                                                        style={{
+                                                            backgroundImage: `url(${houseInfluenceImages.get(h.id)})`,
+                                                            marginTop: "-5px"
+                                                        }}
+                                                    >
+                                                    </div>
+                                            </OverlayTrigger>
+                                        ))}
+                                    </div>
+                                    <div>
+                                        {allowedArmies.map((size, i) => (
+                                            <div style={{marginBottom: "-6px"}} key={i}>
+                                                {size}
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </Col>
+                        ))}
+                    </Row>
+                </Col>
+            </Row>
+        );
+    }
+
+    getHousesAtSupplyLevel(supplyLevel: number): House[] {
+        return this.props.houses.values.filter(h => h.supplyLevel == supplyLevel);
+    }
+}


### PR DESCRIPTION
I targeted this towards `master` branch, since it's pretty isolated. But feel free to adjust to `v1.5-branch` if you feel that's more appropriate.

*NOTE: These images may go stale as we make changes in this pull request to adjust the wording. They just serve as examples.

![supply track](https://user-images.githubusercontent.com/1547356/79951421-7e904400-842d-11ea-8afe-6bd9dc1cbf73.JPG)

![supply header](https://user-images.githubusercontent.com/1547356/79951441-89e36f80-842d-11ea-8bba-b515d631b44a.JPG)
