### PR TITLE
Print remaining Westeros cards to console

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -190,6 +190,14 @@ export default class IngameGameState extends GameState<
         }
     }
 
+    logWesterosDecks(): void {
+        const decks = this.game.westerosDecks.map(deck => (
+            deck.filter(wc => !wc.discarded).map(wc => wc.type.name).sort()
+        ));
+
+        console.log(`Remaining Westeros cards:\n${JSON.stringify(decks, null, 2)}`);
+    }
+
     onServerMessage(message: ServerMessage): void {
         if (message.type == "supply-adjusted") {
             const supplies: [House, number][] = message.supplies.map(([houseId, supply]) => [this.game.houses.get(houseId), supply]);
@@ -297,6 +305,7 @@ export default class IngameGameState extends GameState<
         ingameGameState.gameLogManager = GameLogManager.deserializeFromServer(ingameGameState, data.gameLogManager);
         ingameGameState.childGameState = ingameGameState.deserializeChildGameState(data.childGameState);
 
+        ingameGameState.logWesterosDecks();
         return ingameGameState;
     }
 


### PR DESCRIPTION
Relates to #208 

This PR doesn't solve the issue at all but it at least gives a possibility to see the remaining westeros cards. Right now there is no synch when the server marks a Westeros card as discarded so the log is only print once atm when the game is deserialized. User would need to reload the game to see the current status in a live game. A further PR could create the synch and show the infos as a tool tip.

Console preview:

![image](https://user-images.githubusercontent.com/22304202/80591542-2d301800-8a1e-11ea-8959-8416f21d7cb5.png)
