### PR TITLE
Fix sending empty chat messages, fixes #538

### DIFF
--- a/agot-bg-game-server/src/client/chat-client/ChatClient.ts
+++ b/agot-bg-game-server/src/client/chat-client/ChatClient.ts
@@ -94,6 +94,9 @@ export default class ChatClient {
         if (!channel.connected) {
             return;
         }
+        if (text == null || text.match(/^\s*$/)){
+            return;
+        }
         console.log('Message sent');
         channel.websocket.send(JSON.stringify({type: 'chat_message', text}));
     }


### PR DESCRIPTION
Simply add a second condition, that the text must not be only white characters. 
Also do we need to sanitize this input?