### PR TITLE
WIP: Make the User object ephemeral

### DIFF
--- a/agot-bg-game-server/src/common/GameState.ts
+++ b/agot-bg-game-server/src/common/GameState.ts
@@ -1,6 +1,5 @@
 import {observable} from "mobx";
 import EntireGame from "./EntireGame";
-import User from "../server/User";
 
 type AnyGameState = GameState<any, any> | null;
 
@@ -49,7 +48,7 @@ export default class GameState<ParentGameState extends AnyGameState, ChildGameSt
                 : false;
     }
 
-    getWaitedUsers(): User[] {
+    getWaitedUsers(): string[] {
         if (this.childGameState) {
             return this.childGameState.getWaitedUsers();
         } else {

--- a/agot-bg-game-server/src/server/AuthenticatedClient.ts
+++ b/agot-bg-game-server/src/server/AuthenticatedClient.ts
@@ -1,0 +1,13 @@
+import EntireGame from "../common/EntireGame";
+
+export default class AuthenticatedClient {
+    userId: string;
+    game: EntireGame;
+    client: WebSocket;
+
+    constructor(userId: string, game: EntireGame, client: WebSocket) {
+        this.userId = userId;
+        this.game = game;
+        this.client = client;
+    }
+}

--- a/agot-bg-game-server/src/server/User.ts
+++ b/agot-bg-game-server/src/server/User.ts
@@ -1,5 +1,3 @@
-import {ServerMessage} from "../messages/ServerMessage";
-import * as WebSocket from "ws";
 import EntireGame from "../common/EntireGame";
 import {UserSettings} from "../messages/ClientMessage";
 import {observable} from "mobx";
@@ -8,25 +6,11 @@ export default class User {
     id: string;
     name: string;
     @observable settings: UserSettings;
-    entireGame: EntireGame;
     connectedClients: WebSocket[] = [];
 
-    constructor(id: string, name: string, game: EntireGame, settings: UserSettings = {pbemMode: false}) {
+    constructor(id: string, name: string) {
         this.id = id;
         this.name = name;
-        this.settings = settings;
-        this.entireGame = game;
-    }
-
-    send(message: ServerMessage): void {
-        this.entireGame.sendMessageToClients([this], message);
-    }
-
-    syncSettings(): void {
-        this.entireGame.sendMessageToServer({
-            type: "change-settings",
-            settings: this.settings
-        });
     }
 
     serializeToClient(): SerializedUser {
@@ -37,8 +21,8 @@ export default class User {
         }
     }
 
-    static deserializeFromServer(game: EntireGame, data: SerializedUser): User {
-        return new User(data.id, data.name, game, data.settings);
+    static deserializeFromServer(data: SerializedUser): User {
+        return new User(data.id, data.name);
     }
 }
 


### PR DESCRIPTION
The goal of this PR is to make the `User` class ephemeral in order to make it updated when a change occurs on the website (Username, rank, ...). The idea is that the class would no longer be serialized or stored inside a game but fetched from the API whenever it is needed. `EntireGame` would get a method that allows the code to do just that when it is needed.