### PR TITLE
Lowest bidder for The Horde Descends now has to select two units of the same stronghold/castle if able.

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/SelectUnitsComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/SelectUnitsComponent.tsx
@@ -66,7 +66,15 @@ export default class SelectUnitsComponent extends Component<GameStateComponentPr
             return [];
         }
 
-        return _.difference(this.props.gameState.possibleUnits, _.flatMap(this.selectedUnits.map((_r, us) => us)));
+        let result = _.difference(this.props.gameState.possibleUnits, _.flatMap(this.selectedUnits.map((_r, us) => us)));
+
+        if (this.props.gameState.selectedUnitsMustBeOfSameRegion && this.selectedUnits.size > 0) {
+            const selectedRegion = this.selectedUnits.entries[0][0];
+
+            result = result.filter(u => u.region == selectedRegion);
+        }
+
+        return result;
     }
 
     modifyUnitOnMap(): [Unit, PartialRecursive<UnitOnMapProperties>][] {

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/the-horde-descends-wildling-victory-game-state/TheHordeDescendsWildlingVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/the-horde-descends-wildling-victory-game-state/TheHordeDescendsWildlingVictoryGameState.ts
@@ -28,11 +28,11 @@ export default class TheHordeDescendsWildlingVictoryGameState extends WildlingCa
 
     executeForLowestBidder(house: House): void {
         const strongholdUnits = _.flatMap(
-            this.game.getUnitsOfHouse(house).filter(([region, _]) => region.hasStructure).map(([_, units]) => units)
+            this.game.getUnitsOfHouse(house).filter(([region, _]) => region.hasStructure && region.units.size >=2).map(([_, units]) => units)
         );
 
         if (strongholdUnits.length >= 2) {
-            this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, strongholdUnits, 2);
+            this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, strongholdUnits, 2, false, true);
         } else {
             const units = this.game.world.getUnitsOfHouse(house);
 


### PR DESCRIPTION
Fix #604 

Ideally the selectable units would dynamically change if the first unit was selected. But this would be a bigger change so I guess this is ok as first fix.