### PR TITLE
Fix Renly ability, when seperating footman to attack

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
@@ -1,4 +1,4 @@
-import GameState from "../../../../../../../GameState";
+    import GameState from "../../../../../../../GameState";
 import AfterWinnerDeterminationGameState from "../AfterWinnerDeterminationGameState";
 import SelectUnitsGameState, {SerializedSelectUnitsGameState} from "../../../../../../select-units-game-state/SelectUnitsGameState";
 import Game from "../../../../../../game-data-structure/Game";
@@ -66,9 +66,9 @@ export default class RenlyBaratheonAbilityGameState extends GameState<
                 .filter(region => region.getController() == house)
             : [];
 
-        const regions = [this.combatGameState.houseCombatDatas.get(house).region].concat(supportingRegions);
-
-        return _.flatMap(regions, region => region.units.values.filter(u => u.type == footman));
+        const supportingFootman = _.flatMap(regions, region => supportingRegions.units.values.filter(u => u.type == footman));
+        const fightingFootman = _.flatMap(regions, region => this.combatGameState.houseCombatDatas.get(house).army.filter(u => u.type == footman));
+        return supportingFootman.concat(fightingFootman);
     }
 
     onSelectUnitsEnd(house: House, selectedUnit: [Region, Unit[]][]): void {


### PR DESCRIPTION
[untested]
seperate the filter for footman, all supporting footing and then all footmen which are part of the army.
Fixes #605 