### PR TITLE
Add a tooltip showing the next Wildling Card

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -80,6 +80,10 @@ export default class IngameComponent extends Component<IngameComponentProps> {
             {name: "Action", gameState: ActionGameState, component: ActionComponent}
         ];
 
+        const knowsWildlingCard = this.props.gameClient.authenticatedPlayer != null &&
+            this.props.gameClient.authenticatedPlayer.house.knowsNextWildlingCard;
+        const nextWildlingCard = this.game.wildlingDeck.filter(c => c.id == this.game.clientNextWildlingCardId)[0];
+
         return (
             <>
                 <Col xs={12} lg={3}>
@@ -105,14 +109,21 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                                             <Col xs="auto">
                                                 <OverlayTrigger overlay={
                                                         <Tooltip id="wildling-threat">
-                                                            <b>Wildling Threat</b>
+                                                            <b>Wildling Threat</b>{ knowsWildlingCard && nextWildlingCard ?
+                                                            <><br/><br/><strong><u>{nextWildlingCard.type.name}</u></strong><br/>
+                                                            <strong>Lowest Bidder:</strong> {nextWildlingCard.type.wildlingVictoryLowestBidderDescription}<br/>
+                                                            <strong>Everyone Else:</strong> {nextWildlingCard.type.wildlingVictoryEverybodyElseDescription}<br/><br/>
+                                                            <strong>Highest Bidder:</strong> {nextWildlingCard.type.nightsWatchDescription}
+                                                            </>
+                                                            : <></>
+                                                            }
                                                         </Tooltip>
                                                     }
                                                     placement="bottom"
                                                 >
                                                     <div>
                                                         {this.game.wildlingStrength}
-                                                        <img src={mammothImage} width={32} style={{marginLeft: "5px"}}/>
+                                                        <img src={mammothImage} width={32} style={{marginLeft: "5px"}} className={knowsWildlingCard ? "wildling-highlight" : ""}/>
                                                     </div>
                                                 </OverlayTrigger>
                                             </Col>

--- a/agot-bg-game-server/src/client/game-state-panel/SeeTopWildlingCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/SeeTopWildlingCardComponent.tsx
@@ -16,7 +16,7 @@ export default class SeeTopWildlingCardComponent extends Component<GameStateComp
         return (
             <>
                 <Col xs={12}>
-                    The holder of the Raven sees the card at the top of the Wildling deck
+                    The holder of the Messenger Raven sees the card at the top of the Wildling deck
                     and may choose to either leave it at the top, or put it at the bottom
                     of the deck.
                 </Col>

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -254,6 +254,11 @@ $strong-outline: rgba($outline-color, 0.8);
   transition: all 0.12s linear;
 }
 
+$wildling-outline: rgba(#f8ff00, 0.5);
+.wildling-highlight {
+  filter: drop-shadow(1px 1px 3px $wildling-outline) drop-shadow(-1px -1px 3px $wildling-outline);
+}
+
 .clickable {
   cursor: pointer;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -263,8 +263,13 @@ export default class IngameGameState extends GameState<
             this.game.valyrianSteelBladeUsed = message.used;
         } else if (message.type == "update-westeros-decks") {
             this.game.westerosDecks = message.westerosDecks.map(wd => wd.map(wc => WesterosCard.deserializeFromServer(wc)));
-        }
-        else {
+        } else if (message.type == "hide-top-wildling-card") {
+            this.game.houses.forEach(h => h.knowsNextWildlingCard = false);
+            this.game.clientNextWildlingCardId = null;
+        } else if (message.type == "reveal-top-wildling-card") {
+            this.game.houses.get(message.houseId).knowsNextWildlingCard = true;
+            this.game.clientNextWildlingCardId = message.cardId;
+        } else {
             this.childGameState.onServerMessage(message);
         }
     }
@@ -284,7 +289,7 @@ export default class IngameGameState extends GameState<
         return {
             type: "ingame",
             players: this.players.values.map(p => p.serializeToClient()),
-            game: this.game.serializeToClient(admin),
+            game: this.game.serializeToClient(admin, player != null && player.house.knowsNextWildlingCard),
             gameLogManager: this.gameLogManager.serializeToClient(),
             childGameState: this.childGameState.serializeToClient(admin, player),
         };

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/use-raven-game-state/see-top-wildling-card-game-state/SeeTopWildlingCardGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/use-raven-game-state/see-top-wildling-card-game-state/SeeTopWildlingCardGameState.ts
@@ -40,6 +40,9 @@ export default class SeeTopWildlingCardGameState extends GameState<UseRavenGameS
             }
 
             if (message.action == SeeTopWildlingCardAction.PUT_AT_BOTTOM) {
+                this.ingameGameState.game.houses.forEach(h => h.knowsNextWildlingCard = false);
+                this.entireGame.broadcastToClients({type: "hide-top-wildling-card"});
+
                 const removedCard = this.useRavenGameState.game.wildlingDeck.shift() as WildlingCard;
 
                 this.useRavenGameState.game.wildlingDeck.push(removedCard);
@@ -49,6 +52,16 @@ export default class SeeTopWildlingCardGameState extends GameState<UseRavenGameS
                     ravenHolder: this.ravenHolder.id
                 });
             } else {
+                const wildlingCard = this.ingameGameState.game.wildlingDeck[0] as WildlingCard;
+                this.ravenHolder.knowsNextWildlingCard = true;
+
+                const ravenUser = this.ingameGameState.players.entries.filter(entry => entry[1].house == this.ravenHolder)[0][0];
+                ravenUser.send({
+                    type: "reveal-top-wildling-card",
+                    cardId: wildlingCard.id,
+                    houseId: this.ravenHolder.id
+                });
+
                 this.ingameGameState.log({
                     type: "raven-holder-wildling-card-put-top",
                     ravenHolder: this.ravenHolder.id

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -29,6 +29,8 @@ export default class Game {
     @observable valyrianSteelBladeUsed = false;
     @observable kingsCourtTrack: House[];
     @observable wildlingStrength = 2;
+    // number in clients where house.knowsNextWilldingCard is true, otherwise null.
+    @observable clientNextWildlingCardId: number | null;
     wildlingDeck: WildlingCard[];
     supplyRestrictions: number[][];
     starredOrderRestrictions: number[];
@@ -319,7 +321,7 @@ export default class Game {
         return this.starredOrderRestrictions[place];
     }
 
-    serializeToClient(admin: boolean): SerializedGame {
+    serializeToClient(admin: boolean, knowsNextWildlingCard: boolean): SerializedGame {
         return {
             lastUnitId: this.lastUnitId,
             houses: this.houses.values.map(h => h.serializeToClient()),
@@ -345,7 +347,8 @@ export default class Game {
             skipRavenPhase: this.skipRavenPhase,
             structuresCountNeededToWin: this.structuresCountNeededToWin,
             maxTurns: this.maxTurns,
-            maxPowerTokens: this.maxPowerTokens
+            maxPowerTokens: this.maxPowerTokens,
+            clientNextWidllingCardId: (admin || knowsNextWildlingCard) ? this.wildlingDeck[0].id : null
         };
     }
 
@@ -369,6 +372,7 @@ export default class Game {
         game.structuresCountNeededToWin = data.structuresCountNeededToWin;
         game.maxTurns = data.maxTurns;
         game.maxPowerTokens = data.maxPowerTokens;
+        game.clientNextWildlingCardId = data.clientNextWidllingCardId;
 
         return game;
     }
@@ -392,4 +396,5 @@ export interface SerializedGame {
     structuresCountNeededToWin: number;
     maxTurns: number;
     maxPowerTokens: number;
+    clientNextWidllingCardId: number | null;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/House.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/House.ts
@@ -8,6 +8,7 @@ export default class House {
     id: string;
     name: string;
     color: string;
+    knowsNextWildlingCard: boolean;
     houseCards: BetterMap<string, HouseCard>;
     unitLimits: BetterMap<UnitType, number>;
     @observable powerTokens: number;
@@ -17,6 +18,7 @@ export default class House {
         this.id = id;
         this.name = name;
         this.color = color;
+        this.knowsNextWildlingCard = false;
         this.houseCards = houseCards;
         this.unitLimits = unitLimits;
         this.powerTokens = powerTokens;
@@ -28,6 +30,7 @@ export default class House {
             id: this.id,
             name: this.name,
             color: this.color,
+            knowsNextWildlingCard: this.knowsNextWildlingCard,
             houseCards: this.houseCards.entries.map(([houseCardId, houseCard]) => [houseCardId, houseCard.serializeToClient()]),
             unitLimits: this.unitLimits.map((unitType, limit) => [unitType.id, limit]),
             powerTokens: this.powerTokens,
@@ -36,7 +39,7 @@ export default class House {
     }
 
     static deserializeFromServer(data: SerializedHouse): House {
-        return new House(
+        const house = new House(
             data.id,
             data.name,
             data.color,
@@ -49,6 +52,9 @@ export default class House {
             data.powerTokens,
             data.supplyLevel
         );
+
+        house.knowsNextWildlingCard = data.knowsNextWildlingCard;
+        return house;
     }
 }
 
@@ -56,6 +62,7 @@ export interface SerializedHouse {
     id: string;
     name: string;
     color: string;
+    knowsNextWildlingCard: boolean;
     houseCards: [string, SerializedHouseCard][];
     unitLimits: [string, number][];
     powerTokens: number;

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
@@ -139,6 +139,10 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
             nightsWatchVictory: this.nightsWatchWon
         });
 
+        // hide wildling card
+        this.game.houses.forEach(h => h.knowsNextWildlingCard = false);
+        this.entireGame.broadcastToClients({type: "hide-top-wildling-card"});
+
         // Reveal the wildling card to the players
         this.entireGame.broadcastToClients({
             type: "reveal-wildling-card",

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -11,7 +11,7 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | HouseCardChosen | CombatImmediatelyKilledUnits | SupportDeclared | NewTurn | RemovePlacedOrder
     | MoveUnits | CombatChangeArmy
     | UnitsWounded | ChangeCombatHouseCard | BeginSeeTopWildlingCard
-    | RavenOrderReplaced | ProceedWesterosCard | ChangeGarrison
+    | RavenOrderReplaced | RevealTopWildlingCard | HideTopWildlingCard | ProceedWesterosCard | ChangeGarrison
     | BidDone | GameStateChange | SupplyAdjusted
     | ChangeControlPowerToken | ChangePowerToken | ChangeWildlingStrength | AddGameLog | RevealWildlingCard
     | RemoveUnits | AddUnits | ChangeTracker | ActionPhaseChangeOrder | ChangeStateHouseCard
@@ -120,6 +120,16 @@ interface RavenOrderReplaced {
     type: "raven-order-replaced";
     regionId: string;
     orderId: number;
+}
+
+interface RevealTopWildlingCard {
+    type: "reveal-top-wildling-card";
+    cardId: number;
+    houseId: string;
+}
+
+interface HideTopWildlingCard {
+    type: "hide-top-wildling-card";
 }
 
 interface ProceedWesterosCard {

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -202,6 +202,21 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "5",
+        migrate: (serializedGame: any) => {
+            // Migration for #245
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+                const game = ingame.game;
+
+                game.houses.forEach((h: any) => h.knowsNextWildlingCard = false);
+                game.clientNextWidllingCardId = null;
+            }
+
+            return serializedGame;
+        }
     }
 ];
 


### PR DESCRIPTION
Closes #245 

Tooltip is accessed through the Wildling Threat icon, accessibility is determined by a `knowsNextWildlingCard` parameter under `House`:
- By default, the parameter is set to false.
- When the Messenger Raven holder looks at the top Wildling card and keeps it, their parameter is set to true.
- When the Messenger Raven holder looks at the top Wildling card and puts it at the bottom, the parameter is set to false for all houses.
- After Wildling bidding is done, the parameter is set to false for all houses.

Tooltip:
- `knowsNextWildlingCard` = false (unchanged):
![image](https://user-images.githubusercontent.com/18612633/80872938-c9c41580-8cbd-11ea-83ed-699459dff9fc.png)

- `knowsNextWildlingCard` = true:
![image](https://user-images.githubusercontent.com/18612633/80872956-f415d300-8cbd-11ea-84b1-4e701ea6c925.png)

![image](https://user-images.githubusercontent.com/18612633/80872945-d6486e00-8cbd-11ea-83e9-3ac97fc115fe.png)

- `SeeTopWildlingCardComponent` (changed text):
![image](https://user-images.githubusercontent.com/18612633/80872972-0db71a80-8cbe-11ea-99cd-a21094f56d8f.png)

 