### PR TITLE
Rearrange combat states to do AfterWinnerDeterminationGameState after retreat is done and attacking army marched into embattled region

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
@@ -199,7 +199,7 @@ export default class PostCombatGameState extends GameState<
         // Put the house cards as used
         this.combat.houseCombatDatas.forEach(({houseCard}, house) => this.markHouseAsUsed(house, houseCard));
 
-        this.proceedAfterWinnerDetermination();
+        this.proceedRetreat();
     }
 
     proceedAfterWinnerDetermination(): void {
@@ -208,7 +208,7 @@ export default class PostCombatGameState extends GameState<
     }
 
     onAfterWinnerDeterminationFinish(): void {
-        this.proceedRetreat();
+        this.setChildGameState(new AfterCombatHouseCardAbilitiesGameState(this)).firstStart();
     }
 
     proceedRetreat(): void {
@@ -251,7 +251,7 @@ export default class PostCombatGameState extends GameState<
         // Remove the order from attacking region
         this.removeOrderFromRegion(this.combat.attackingRegion);
 
-        this.setChildGameState(new AfterCombatHouseCardAbilitiesGameState(this)).firstStart();
+        this.proceedAfterWinnerDetermination();
     }
 
     removeOrderFromRegion(region: Region): void {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/renly-baratheon-ability-game-state/RenlyBaratheonAbilityGameState.ts
@@ -66,9 +66,10 @@ export default class RenlyBaratheonAbilityGameState extends GameState<
                 .filter(region => region.getController() == house)
             : [];
 
-        const regions = [this.combatGameState.houseCombatDatas.get(house).region].concat(supportingRegions);
+        const upgradableFootmen = _.flatMap(supportingRegions, r => r.units.values).filter(u => u.type == footman);
+        upgradableFootmen.push(...this.combatGameState.houseCombatDatas.get(house).army.filter(u => u.type == footman));
 
-        return _.flatMap(regions, region => region.units.values.filter(u => u.type == footman));
+        return upgradableFootmen;
     }
 
     onSelectUnitsEnd(house: House, selectedUnit: [Region, Unit[]][]): void {


### PR DESCRIPTION
Fix #605 

This is not tested yet. I just assume it might fix the issue and I don't see a problem by switching the states atm and do AfterWinner abilities after retreat and march of the battle is finally handled. Some running games might get corrupted though.


Current `AfterWinnerDeterminationGameState`s:

- Cersei
- Renly
- Roose
- Tywin