### PR TITLE
Disallow further moves after an attack has already been triggered

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
@@ -300,8 +300,8 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
         return this.world.getReachableRegions(startingRegion, this.house, movingArmy)
             // Filter out destinations that are already used
             .filter(r => !moves.map(([r, _a]) => r).includes(r))
-            // Check that this new move doesn't trigger another attack
-            .filter(r => attackMoveAlreadyPresent ? !this.doesMoveTriggerAttack(r) : true)
+            // To correctly handle supply check, no further moves must be allowed when an attack has already been triggered
+            .filter(_r => !attackMoveAlreadyPresent)
             // Check that if the destination a port, the adjacent land area must
             // be controlled by the resolver
             .filter(r => r.type == port ? this.world.getAdjacentLandOfPort(r).getController() == this.house : true)


### PR DESCRIPTION
Fix #140 

I verified your suggestion and was about to PR it that way. Right before turning off my PC one situation came to my mind. By only checking non-combat-moves you will be able to break supply by splitting a 4-unit army into two 2-unit-armies. So the problem is that you can do moves after you already triggered an attack.

Here e.g. White Harbor is not available when you just select one unit for marching (it will result in 3 armies which isn't allowed for Stark in the beginning):

![image](https://user-images.githubusercontent.com/22304202/81609797-c8d76600-93d8-11ea-880f-ceefc1525194.png)

But after attacking Dragonstone with one unit it becomes reachable again (The current implementation assumes the attack to Dragonstone is successful):

![image](https://user-images.githubusercontent.com/22304202/81609881-e7d5f800-93d8-11ea-9cea-4892b3fc2a7f.png)

So to handle all scenarios properly the only solution imo is to disallow any further moves after an attack has already been triggered:

![image](https://user-images.githubusercontent.com/22304202/81621469-c2ec7f80-93ee-11ea-8eb6-6bcbce9328d7.png)
