### PR TITLE
Hide house icon and name in Lobby when "Randomize houses" is selected

### DIFF
--- a/agot-bg-game-server/src/client/LobbyComponent.tsx
+++ b/agot-bg-game-server/src/client/LobbyComponent.tsx
@@ -32,6 +32,10 @@ export default class LobbyComponent extends Component<LobbyComponentProps> {
         return this.props.gameClient.authenticatedUser as User;
     }
 
+    get randomHouses(): boolean {
+        return this.props.gameState.entireGame.gameSettings.randomHouses;
+    }
+
     render(): ReactNode {
         const {success: canStartGame, reason: canStartGameReason} = this.props.gameState.canStartGame(this.authenticatedUser);
         const {success: canCancelGame, reason: canCancelGameReason} = this.props.gameState.canCancel(this.authenticatedUser);
@@ -42,17 +46,17 @@ export default class LobbyComponent extends Component<LobbyComponentProps> {
                     <Col>
                         <Card>
                             <ListGroup variant="flush">
-                                {this.props.gameState.lobbyHouses.values.map(h => (
+                                {this.props.gameState.lobbyHouses.values.map((h, i) => (
                                     <ListGroupItem key={h.id} style={{opacity: this.isHouseAvailable(h) ? 1 : 0.3}}>
                                         <Row className="align-items-center">
-                                            <Col xs="auto">
+                                            {!this.randomHouses && <Col xs="auto">
                                                 <div className="influence-icon"
                                                      style={{backgroundImage: `url(${houseInfluenceImages.get(h.id)})`}}>
                                                 </div>
-                                            </Col>
+                                            </Col>}
                                             <Col>
                                                 <div>
-                                                    <b>{h.name}</b>
+                                                    <b>{this.randomHouses ? "Seat " + (i + 1): h.name}</b>
                                                 </div>
                                                 <div className={classNames({"invisible": !this.props.gameState.players.has(h)})}>
                                                     {this.props.gameState.players.has(h) ? (


### PR DESCRIPTION
This PR has no source issue. It was an idea from Jason77 as we started our first private random PBEM today. It wasn't clear for him that this game has random house option and his idea was to hide the house icons. I liked this idea and as it was quite simple to implement I thought I will directly PR it instead of starting a discussion. Hope it's okay.

Preview:

![WhatsApp Image 2020-05-26 at 09 50 54](https://user-images.githubusercontent.com/22304202/82875428-a7798c80-9f37-11ea-8e1c-5533d6910b2c.jpeg)
