### PR TITLE
Fix typo and unify wordings

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
@@ -34,11 +34,11 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
             <>
                 <Col xs={12}>
                     {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER ? (
-                        <>House {this.house.name} can resolve one of its Consolidate Power Orders</>
+                        <>House <b>{this.house.name}</b> must resolve one of its Consolidate Power Orders.</>
                     ) : this.props.gameState.type == PlayerMusteringType.MUSTERING_WESTEROS_CARD ? (
-                        <>Players can muster units in their controlled castles and fortresses</>
+                        <>Players can muster units in their controlled castles and fortresses.</>
                     ) : this.props.gameState.type == PlayerMusteringType.THE_HORDE_DESCENDS_WILDLING_CARD && (
-                        <></>
+                        <>House <b>{this.house.name}</b> can muster units in one of their controlled castles or fortresses.</>
                     )}
                 </Col>
                 {this.props.gameClient.doesControlHouse(this.house) ? (
@@ -61,13 +61,9 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                         )}
                         {!(this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER && this.musterings.size > 0) && (
                             <Col xs={12}>
-                                {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER ? (
-                                    <>Click on a Consolidate Power Order to resolve it.</>
-                                ) : this.props.gameState.type == PlayerMusteringType.MUSTERING_WESTEROS_CARD ? (
-                                    <>Click on a region to initiate a recruitement from there.</>
-                                ) : this.props.gameState.type == PlayerMusteringType.THE_HORDE_DESCENDS_WILDLING_CARD && (
-                                    <>...</>
-                                )}
+                                {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER ?
+                                    <>Click on a Consolidate Power Order token to resolve it.</>
+                                  : <>Click on a region to initiate a recruitment from there.</>}
                             </Col>
                         )}
                         {this.selectedRegion && (

--- a/agot-bg-game-server/src/client/game-state-panel/ResolveSingleMarchOrderComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveSingleMarchOrderComponent.tsx
@@ -33,18 +33,18 @@ export default class ResolveSingleMarchOrderComponent extends Component<GameStat
         return (
             <>
                 <Col xs={12} className="text-center">
-                    <strong>{this.props.gameState.house.name}</strong> must resolve one of
-                    its march orders.
+                    House <b>{this.props.gameState.house.name}</b> must resolve one of
+                    its March Orders.
                 </Col>
                 {this.props.gameClient.doesControlHouse(this.props.gameState.house) ? (
                     <>
                         <Col xs={12} className="text-center">
                             {this.selectedMarchOrderRegion == null ? (
-                                "Click on one of your march order"
+                                "Click on one of your March Orders."
                             ) : this.selectedUnits.length == 0 ? (
-                                "Click on a subset of the troops in the marching region"
+                                "Click on a subset of the troops in the marching region."
                             ) : (
-                                "Click on a neighbouring region, or click on other units of the marching region"
+                                "Click on a neighbouring region, or click on other units of the marching region."
                             )}
                         </Col>
                         {this.plannedMoves.size > 0 && (
@@ -81,7 +81,7 @@ export default class ResolveSingleMarchOrderComponent extends Component<GameStat
                     </>
                 ) : (
                     <Col xs={12} className="text-center">
-                        Waiting for {this.props.gameState.house.name} to resolve one of its march order...
+                        Waiting for {this.props.gameState.house.name}...
                     </Col>
                 )}
             </>
@@ -168,7 +168,7 @@ export default class ResolveSingleMarchOrderComponent extends Component<GameStat
         }
 
         if(this.plannedMoves.size == 0) {
-            if(!confirm("Do you want to remove your march order?")) {
+            if(!confirm("Do you want to remove your March Order?")) {
                 return;
             }
         }

--- a/agot-bg-game-server/src/client/game-state-panel/ResolveSingleRaidOrderComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveSingleRaidOrderComponent.tsx
@@ -26,12 +26,12 @@ export default class ResolveSingleRaidOrderComponent extends Component<GameState
         return (
             <>
                 <Col xs={12} className="text-center">
-                    {this.props.gameState.house.name} must resolve one of its raid orders.
+                    House <b>{this.props.gameState.house.name}</b> must resolve one of its Raid Orders.
                 </Col>
                 {this.props.gameClient.authenticatedPlayer && this.props.gameState.house == this.props.gameClient.authenticatedPlayer.house ? (
                     this.selectedOrderRegion == null ? (
                         <Col xs={12} className="text-center">
-                            Select a raid order token to resolve it
+                            Select a Raid Order token to resolve it.
                         </Col>
                     ) : (
                         <>
@@ -66,7 +66,7 @@ export default class ResolveSingleRaidOrderComponent extends Component<GameState
     confirm(): void {
         if (this.selectedOrderRegion) {
             if (!this.selectedTargetRegion) {
-                if (!window.confirm('Do you want to remove your Raid order?')) {
+                if (!window.confirm('Do you want to remove your Raid Order?')) {
                     return;
                 }
             }

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -3,6 +3,11 @@ $grid-gutter-width: 1rem;
 @import './theme/_variables';
 @import '../../../node_modules/bootstrap/scss/bootstrap';
 
+strong 
+{ 
+  font-weight: bold; 
+}
+
 .row {
   margin-top: -0.5rem;
   margin-bottom: -0.5rem;


### PR DESCRIPTION
It all started as I realized a typo in "Waiting for Stark to resolve one of its march order..." which finally resulted in this PR.

In addition I learned today that `<strong>` not necessarily is shown bold in all browers. Instead of fixing all occurrences to `<b>` a recommendation on stackoverflow was to specify `font-weight: bold` in the CSS. I can remove that commit if you don't like it.