### PR TITLE
Fix Crow Killers: Take available footman into account when replacing knights

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -877,9 +877,16 @@ export default class GameLogListComponent extends Component<GameLogListComponent
 
                 return <>
                     {units.length > 0
-                    ? (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Knights in <strong>{region.name}</strong></>), ", ")} with Footmen.</>)
+                    ? (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Knight{unitTypes.length > 1 && "s"} in <strong>{region.name}</strong></>), ", ")} with Footmen.</>)
                     : (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> had no Knights to replace with Footmen.</>)}
                 </>;
+
+            case "crow-killers-knights-killed": {
+                const house = this.game.houses.get(data.house);
+                const units: [Region, UnitType[]][] = data.units.map(([rid, utids]) => [this.world.regions.get(rid), utids.map(utid => unitTypes.get(utid))]);
+
+                return <><b>Crow Killers</b>: <b>{house.name}</b> had to destroy {joinReactNodes(units.map(([region, unitTypes]) => <><b>{unitTypes.length}</b> Knight{unitTypes.length > 1 && "s"} in <b>{region.name}</b></>), ", ")}.</>;
+            }
 
             case "crow-killers-footman-upgraded":
                 house = this.game.houses.get(data.house);
@@ -887,7 +894,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
 
                 return <>
                     {units.length > 0
-                    ? (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Footmen in <strong>{region.name}</strong></>), ", ")} with Knights.</>)
+                    ? (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> replaced {joinReactNodes(units.map(([region, unitTypes]) => <><strong>{unitTypes.length}</strong> Footm{unitTypes.length == 1 ? "a" : "e"}n in <strong>{region.name}</strong></>), ", ")} with Knights.</>)
                     : (<><strong>Crow Killers</strong>: <strong>{house.name}</strong> was not able to replace any Footman with Knights.</>)}
                 </>;
 

--- a/agot-bg-game-server/src/client/game-state-panel/SelectUnitsComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/SelectUnitsComponent.tsx
@@ -59,6 +59,7 @@ export default class SelectUnitsComponent extends Component<GameStateComponentPr
         }
 
         this.props.gameState.selectUnits(this.selectedUnits);
+        this.selectedUnits = new BetterMap();
     }
 
     getSelectableUnits(): Unit[] {

--- a/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/CrowKillersWildlingVictoryComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/CrowKillersWildlingVictoryComponent.tsx
@@ -4,7 +4,7 @@ import GameStateComponentProps from "../GameStateComponentProps";
 import renderChildGameState from "../../utils/renderChildGameState";
 import SelectUnitsGameState from "../../../common/ingame-game-state/select-units-game-state/SelectUnitsGameState";
 import SelectUnitsComponent from "../SelectUnitsComponent";
-import CrowKillersWildlingVictoryGameState
+import CrowKillersWildlingVictoryGameState, { CrowKillersStep }
     from "../../../common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState";
 import Col from "react-bootstrap/Col";
 import React from "react";
@@ -14,10 +14,15 @@ export default class CrowKillersWildlingVictoryComponent extends Component<GameS
     render(): ReactNode {
         return (
             <>
-                <Col xs={12}>
-                    <b>{this.props.gameState.childGameState.house.name}</b> replaces {this.props.gameState.childGameState.count} of their Knights with
-                    available Footmen.
-                </Col>
+                {this.props.gameState.step == CrowKillersStep.DEGRADING_KNIGHTS ?
+                    <Col xs={12}>
+                        <b>{this.props.gameState.childGameState.house.name}</b> replaces {this.props.gameState.childGameState.count} of their Knights with
+                        available Footmen.
+                    </Col> : this.props.gameState.step == CrowKillersStep.DESTROYING_KNIGHTS ?
+                    <Col xs={12}>
+                        <b>{this.props.gameState.childGameState.house.name}</b> has to destroy {this.props.gameState.childGameState.count} of their Knights before
+                        the rest can be replaced with Footmen.
+                    </Col> : <Col xs={12}>Invalid CrowKillersStep!</Col>}
                 {renderChildGameState(this.props, [
                     [SelectUnitsGameState, SelectUnitsComponent]
                 ])}

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -24,7 +24,7 @@ export type GameLogData = TurnBegin | SupportDeclared | SupportRefused | Attack 
     | MassingOnTheMilkwaterHouseCardsRemoved
     | AKingBeyondTheWallHighestTopTrack | AKingBeyondTheWallHouseReduceTrack | AKingBeyondTheWallLowestReduceTracks
     | MammothRidersDestroyUnits | MammothRidersReturnCard | TheHordeDescendsHighestMuster | TheHordeDescendsUnitsKilled
-    | CrowKillersFootmanUpgraded | CrowKillersKnightsReplaced
+    | CrowKillersFootmanUpgraded | CrowKillersKnightsReplaced | CrowKillersKnightsKilled
     | SkinchangerScoutNightsWatchVictory | SkinchangerScoutWildlingVictory
     | RattleshirtsRaidersNightsWatchVictory | RattleshirtsRaidersWildlingVictory
     | GameOfThronesPowerTokensGained | ImmediatelyBattleCasualtiesSuffered | BattleCasualtiesSuffered
@@ -503,6 +503,12 @@ interface TheHordeDescendsUnitsKilled {
 
 interface CrowKillersKnightsReplaced {
     type: "crow-killers-knights-replaced";
+    house: string;
+    units: [string, string[]][];
+}
+
+interface CrowKillersKnightsKilled {
+    type: "crow-killers-knights-killed";
     house: string;
     units: [string, string[]][];
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
@@ -27,7 +27,6 @@ import MammothRidersNightsWatchVictoryGameState, {SerializedMammothRidersNightsW
 import TheHordeDescendsWildlingVictoryGameState, {SerializedTheHordeDescendsWildlingVictoryGameState} from "./the-horde-descends-wildling-victory-game-state/TheHordeDescendsWildlingVictoryGameState";
 import TheHordeDescendsNightsWatchVictoryGameState, {SerializedTheHordeDescendsNightsWatchVictoryGameState} from "./the-horde-descends-nights-watch-victory-game-state/TheHordeDescendsNightsWatchVictoryGameState";
 import IngameGameState from "../../IngameGameState";
-import { silenceAtTheWall } from "../../game-data-structure/wildling-card/wildlingCardTypes";
 
 export default class WildlingsAttackGameState extends GameState<WesterosGameState,
     BiddingGameState<WildlingsAttackGameState> | SimpleChoiceGameState | PreemptiveRaidWildlingVictoryGameState

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState.ts
@@ -10,8 +10,19 @@ import {ClientMessage} from "../../../../../messages/ClientMessage";
 import {ServerMessage} from "../../../../../messages/ServerMessage";
 import WildlingsAttackGameState from "../WildlingsAttackGameState";
 import IngameGameState from "../../../IngameGameState";
+import { observable } from "mobx";
+
+export enum CrowKillersStep {
+    DEGRADING_KNIGHTS,
+    DESTROYING_KNIGHTS
+}
 
 export default class CrowKillersWildlingVictoryGameState extends WildlingCardEffectInTurnOrderGameState<SelectUnitsGameState<CrowKillersWildlingVictoryGameState>> {
+    @observable
+    step: CrowKillersStep = CrowKillersStep.DEGRADING_KNIGHTS;
+
+    static readonly EVERYONE_ELSE_REPLACE_COUNT = 2;
+
     get ingame(): IngameGameState {
         return this.parentGameState.parentGameState.ingame;
     }
@@ -23,16 +34,31 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
             .filter(r => r.units.values.some(u => u.type == knight))
             .map(r => [r, r.units.values.filter(u => u.type == knight)] as [Region, Unit[]]);
 
-        this.transformSelection(house, knightsToTransform);
+        const flattenedKnights = _.flatMap(knightsToTransform, ([_region, units]) => units);
+        const availableFootmanCount = this.game.getAvailableUnitsOfType(house, footman);
+
+        if (flattenedKnights.length <= availableFootmanCount) {
+            this.transformSelection(house, knightsToTransform);
+        } else {
+            this.step = CrowKillersStep.DESTROYING_KNIGHTS;
+            this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, flattenedKnights, flattenedKnights.length - availableFootmanCount);
+        }
     }
 
     executeForEveryoneElse(house: House): void {
         const selectableKnights = this.getSelectableKnights(house);
 
         if (selectableKnights.length > 0) {
-            const count = Math.min(selectableKnights.length, 2);
+            const count = Math.min(selectableKnights.length, CrowKillersWildlingVictoryGameState.EVERYONE_ELSE_REPLACE_COUNT);
 
-            this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, selectableKnights, count);
+            const availableFootmanCount = this.game.getAvailableUnitsOfType(house, footman);
+
+            if (count <= availableFootmanCount) {
+                this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, selectableKnights, count);
+            } else {
+                this.step = CrowKillersStep.DESTROYING_KNIGHTS;
+                this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, selectableKnights, count - availableFootmanCount);
+            }
         } else {
             this.ingame.log({
                 type: "crow-killers-knights-replaced",
@@ -48,10 +74,46 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
         this.childGameState.onPlayerMessage(player, message);
     }
 
-    onServerMessage(_message: ServerMessage): void { }
+    onServerMessage(message: ServerMessage): void {
+        if (message.type == "crow-killers-step-changed") {
+            this.step = message.newStep;
+        }
+    }
 
     onSelectUnitsEnd(house: House, selectedUnits: [Region, Unit[]][]): void {
-        this.transformSelection(house, selectedUnits);
+        if (this.step == CrowKillersStep.DESTROYING_KNIGHTS) {
+            const killedUnitCount = this.destroySelection(house, selectedUnits);
+
+            this.step = CrowKillersStep.DEGRADING_KNIGHTS;
+
+            if (house == this.parentGameState.lowestBidder) {
+                // We can now safely call executeForLowestBidder and transform all remaining knights
+                // as lowestBidder removed enough knights
+                this.executeForLowestBidder(house);
+            } else {
+                const selectableKnights = this.getSelectableKnights(house);
+                if (selectableKnights.length > 0 && CrowKillersWildlingVictoryGameState.EVERYONE_ELSE_REPLACE_COUNT - killedUnitCount > 0) {
+                    const count = Math.min(selectableKnights.length, CrowKillersWildlingVictoryGameState.EVERYONE_ELSE_REPLACE_COUNT - killedUnitCount);
+                    this.ingame.entireGame.broadcastToClients({
+                        type: "crow-killers-step-changed",
+                        newStep: this.step
+                    });
+                    this.setChildGameState(new SelectUnitsGameState(this)).firstStart(house, selectableKnights, count);
+                } else {
+                    this.ingame.log({
+                        type: "crow-killers-knights-replaced",
+                        house: house.id,
+                        units: []
+                    });
+
+                    this.proceedNextHouse(house);
+                }
+            }
+        } else if (this.step == CrowKillersStep.DEGRADING_KNIGHTS) {
+            this.transformSelection(house, selectedUnits);
+        } else {
+            throw new Error("Invalid CrowKillersStep received.");
+        }
     }
 
     getSelectableKnights(house: House): Unit[] {
@@ -59,7 +121,43 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
             .filter(u => u.type == knight);
     }
 
+    destroySelection(house: House, selectedUnits: [Region, Unit[]][]): number {
+        // Wildlings attacks only happen during Westeros phase and therefore we don't need to remove possible orphaned orders here.
+        // Orphaned ship handling is already done globally for all wildling effects in base.proceedNextHouse().
+
+        if (selectedUnits.length == 0) {
+            return 0;
+        }
+
+        let count = 0;
+        selectedUnits.forEach(([region, units]) => {
+            count += units.length;
+            const unitIdsToDestroy = units.map(u => u.id);
+            unitIdsToDestroy.forEach(uid => region.units.delete(uid));
+
+            this.entireGame.broadcastToClients({
+                type: "remove-units",
+                regionId: region.id,
+                unitIds: unitIdsToDestroy
+            });
+        });
+
+        this.ingame.log({
+            type: "crow-killers-knights-killed",
+            house: house.id,
+            units: selectedUnits.map(([region, knights]) => [region.id, knights.map(k => k.type.id)])
+        });
+
+        return count;
+    }
+
     transformSelection(house: House, selectedUnits: [Region, Unit[]][]): void {
+        const unitCount = _.flatMap(selectedUnits, ([_region, units]) => units).length;
+
+        if (unitCount > this.game.getAvailableUnitsOfType(house, footman)) {
+            throw new Error("Not enough footman for transformation!");
+        }
+
         selectedUnits.forEach(([region, knights]) => this.ingame.transformUnits(region, knights, footman));
 
         this.ingame.log({
@@ -74,7 +172,8 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
     serializeToClient(admin: boolean, player: Player | null): SerializedCrowKillersWildlingVictoryGameState {
         return {
             type: "crow-killers-wildling-victory",
-            childGameState: this.childGameState.serializeToClient(admin, player)
+            childGameState: this.childGameState.serializeToClient(admin, player),
+            step: this.step
         }
     }
 
@@ -82,6 +181,7 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
         const crowKillers = new CrowKillersWildlingVictoryGameState(wildlingsAttack);
 
         crowKillers.childGameState = crowKillers.deserializeChildGameState(data.childGameState);
+        crowKillers.step = data.step;
 
         return crowKillers;
     }
@@ -94,4 +194,5 @@ export default class CrowKillersWildlingVictoryGameState extends WildlingCardEff
 export interface SerializedCrowKillersWildlingVictoryGameState {
     type: "crow-killers-wildling-victory";
     childGameState: SerializedSelectUnitsGameState;
+    step: CrowKillersStep;
 }

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -7,6 +7,7 @@ import {GameLogData} from "../common/ingame-game-state/game-data-structure/GameL
 import {UserSettings} from "./ClientMessage";
 import { SerializedWesterosCard } from "../common/ingame-game-state/game-data-structure/westeros-card/WesterosCard";
 import { SerializedVote } from "../common/ingame-game-state/vote-system/Vote";
+import { CrowKillersStep } from "../common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState";
 
 export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | OrderPlaced | PlayerReady | PlayerUnready
     | HouseCardChosen | CombatImmediatelyKilledUnits | SupportDeclared | SupportRefused | NewTurn | RemovePlacedOrder
@@ -17,7 +18,8 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | ChangeControlPowerToken | ChangePowerToken | ChangeWildlingStrength | AddGameLog | RevealWildlingCard
     | RemoveUnits | AddUnits | ChangeTracker | ActionPhaseChangeOrder | ChangeStateHouseCard
     | SettingsChanged | ChangeValyrianSteelBladeUse | BiddingNextTrack | NewPrivateChatRoom | GameSettingsChanged
-    | UpdateWesterosDecks | UpdateConnectionStatus | VoteStarted | VoteCancelled | VoteDone | PlayerReplaced;
+    | UpdateWesterosDecks | UpdateConnectionStatus | VoteStarted | VoteCancelled | VoteDone | PlayerReplaced
+    | CrowKillersStepChanged;
 
 interface AuthenticationResponse {
     type: "authenticate-response";
@@ -281,4 +283,9 @@ interface PlayerReplaced {
     type: "player-replaced";
     oldUser: string;
     newUser: string;
+}
+
+interface CrowKillersStepChanged {
+    type: "crow-killers-step-changed";
+    newStep: CrowKillersStep;
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -1,6 +1,7 @@
 import BetterMap from "../utils/BetterMap";
 import unitTypes from "../common/ingame-game-state/game-data-structure/unitTypes";
 import staticWorld from "../common/ingame-game-state/game-data-structure/static-data-structure/globalStaticWorld";
+import { CrowKillersStep } from "../common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState";
 
 const serializedGameMigrations: {version: string; migrate: (serializeGamed: any) => any}[] = [
     {
@@ -234,6 +235,34 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
                     const playersToHouse = new BetterMap(ingame.players.map((serializedPlayer: any) => [serializedPlayer.userId, serializedPlayer.houseId]));
 
                     planning.readyHouses = planning.readyPlayers.map((playerId: string) => playersToHouse.get(playerId));
+                }
+            }
+
+            return serializedGame;
+        }
+    },
+    {
+        version: "7",
+        migrate: (serializedGame: any) => {
+            // Migration for #690
+
+            // Check if game is currently in "CrowKillersWildlingsVictoryGameState"
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+                
+                if (ingame.childGameState && ingame.childGameState.type == "westeros") {
+                    const westeros = ingame.childGameState;
+
+                    if (westeros.childGameState && westeros.childGameState.type == "wildlings-attack") {
+                        const wildlingsAttack = westeros.childGameState;
+
+                        if (wildlingsAttack.childGameState && wildlingsAttack.childGameState == "crow-killers-wildling-victory") {
+                            const crowKillersWildlingVictory = wildlingsAttack.childGameState;
+
+                            // We assume no game is in the potential buggy state where we would have to apply KILLING_KNIGHTS
+                            crowKillersWildlingVictory.step = CrowKillersStep.DEGRADING_KNIGHTS;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Fix #685 

As described on Discord this PR solves the problem in general. For lowest bidder everything is straight forward but there is a problem with updating the UI when "everyone else" performs their action:

User has to kill 1 knight before he can continue:

![crow-killers-fix-prev1](https://user-images.githubusercontent.com/22304202/84044809-53938c80-a9a8-11ea-9dcd-a3a0a68c4f7b.PNG)

UI isn't updated after it's done:

![crow-killers-fix-prev2](https://user-images.githubusercontent.com/22304202/84044964-876eb200-a9a8-11ea-849d-138ba3e15731.PNG)

Doing browser reload resolves the issue:

![crow-killers-fix-prev3](https://user-images.githubusercontent.com/22304202/84045055-a2412680-a9a8-11ea-959c-ee73ec5bc886.PNG)


Last but not least the game log:

![image](https://user-images.githubusercontent.com/22304202/84049051-424c7f00-a9ac-11ea-8eb7-e0a1b7cfcaac.png)

We don't need a migration for `CrowKillersStep`, do we?

If needed I can send a `baseGameData.json` to quickly test this scenario.