### PR TITLE
Add full date tooltip to GameLog

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -19,6 +19,7 @@ import _ from "lodash";
 import joinReactNodes from "./utils/joinReactNodes";
 import orders from "../common/ingame-game-state/game-data-structure/orders";
 import CombatInfoComponent from "./CombatInfoComponent";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
 
 interface GameLogListComponentProps {
     ingameGameState: IngameGameState;
@@ -38,10 +39,16 @@ export default class GameLogListComponent extends Component<GameLogListComponent
         return this.props.ingameGameState.gameLogManager.logs.map((l, i) => (
             <Row key={i}>
                 <Col xs="auto" className="text-muted">
-                    <small>
-                        {l.time.getHours().toString().padStart(2, "0")}
-                        :{l.time.getMinutes().toString().padStart(2, "0")}
-                    </small>
+                    <OverlayTrigger
+                        placement="auto"
+                        overlay={<Tooltip id={"log-date-" + l.time.getUTCMilliseconds()}>{l.time.toLocaleString()}</Tooltip>}
+                        popperConfig={{ modifiers: { preventOverflow: { boundariesElement: "viewport" } } }}
+                    >
+                        <small>
+                            {l.time.getHours().toString().padStart(2, "0")}
+                            :{l.time.getMinutes().toString().padStart(2, "0")}
+                        </small>
+                    </OverlayTrigger>
                 </Col>
                 <Col>
                     <div className="game-log-content">


### PR DESCRIPTION
I thought #683 might be helpful for the game log also. So I quickly did it:

![image](https://user-images.githubusercontent.com/22304202/84627780-c5f3f780-aee7-11ea-851f-68dce373e298.png)
