### PR TITLE
Replace "Leave a Power Token" checkbox with radio buttons

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/ResolveSingleMarchOrderComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveSingleMarchOrderComponent.tsx
@@ -31,6 +31,7 @@ export default class ResolveSingleMarchOrderComponent extends Component<GameStat
     modifyOrdersOnMapCallback: any;
 
     render(): ReactNode {
+        const allUnitsLeft = this.selectedMarchOrderRegion ? this.props.gameState.haveAllUnitsLeft(this.selectedMarchOrderRegion, this.plannedMoves) : false;
         return (
             <>
                 <Col xs={12} className="text-center">
@@ -42,11 +43,11 @@ export default class ResolveSingleMarchOrderComponent extends Component<GameStat
                         <Col xs={12} className="text-center">
                             {this.selectedMarchOrderRegion == null ? (
                                 "Click on one of your March Orders."
-                            ) : this.selectedUnits.length == 0 ? (
-                                "Click on a subset of the troops in the marching region."
-                            ) : (
-                                "Click on a neighbouring region, or click on other units of the marching region."
-                            )}
+                            ) : this.selectedUnits.length == 0 && !allUnitsLeft ? (
+                                <>Click on a subset of the troops in <b>{this.selectedMarchOrderRegion.name}</b>.</>
+                            ) : !allUnitsLeft ? (
+                                <>Click on a neighbouring region, or click on other units in <b>{this.selectedMarchOrderRegion.name}</b>.</>
+                            ) : (<></>)}
                         </Col>
                         {this.plannedMoves.size > 0 && (
                             <Col xs={12} className="text-center">
@@ -115,7 +116,7 @@ export default class ResolveSingleMarchOrderComponent extends Component<GameStat
     }
 
     renderLeavePowerToken(startingRegion: Region): ReactNode | null {
-        return (
+        return this.plannedMoves.size > 0 && (
             <Col xs={12} className="text-center">
                 <OverlayTrigger overlay={
                     <Tooltip id={"leave-power-token"}>

--- a/agot-bg-game-server/src/client/game-state-panel/SelectOrdersComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/SelectOrdersComponent.tsx
@@ -25,7 +25,7 @@ export default class SelectOrdersComponent extends Component<GameStateComponentP
                 <Col xs={12}>
                     {this.props.gameClient.doesControlHouse(this.props.gameState.house) ? (
                         <>
-                            {this.selectedRegions.length > 0 && 
+                            {this.selectedRegions.length > 0 &&
                             <Row className="justify-content-center">
                                 <p>Selected region{this.selectedRegions.length > 1 && "s"}: {joinReactNodes(this.selectedRegions.map(r => <b key={r.id}>{r.name}</b>), ', ')}</p>
                             </Row>}

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -3,9 +3,9 @@ $grid-gutter-width: 1rem;
 @import './theme/_variables';
 @import '../../../node_modules/bootstrap/scss/bootstrap';
 
-strong 
-{ 
-  font-weight: bold; 
+strong
+{
+  font-weight: bold;
 }
 
 .row {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
@@ -421,11 +421,15 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
         }
 
         // The player can place a power token if all units go out
-        if (_.sum(moves.values.map(us => us.length)) < startingRegion.units.size) {
+        if (!this.haveAllUnitsLeft(startingRegion, moves)) {
             return {success: false, reason: "no-all-units-go"}
         }
 
         return {success: true, reason: "ok"};
+    }
+
+    haveAllUnitsLeft(startingRegion: Region, moves: BetterMap<Region, Unit[]>): boolean {
+        return _.sum(moves.values.map(us => us.length)) == startingRegion.units.size;
     }
 
     static deserializeFromServer(resolveMarchOrderGameState: ResolveMarchOrderGameState, data: SerializedResolveSingleMarchOrderGameState): ResolveSingleMarchOrderGameState {


### PR DESCRIPTION
Closes #697

I decided to replace the checkbox with radio buttons to avoid regularly dialogs. They now behave the following way.

If `canLeavePowerToken()` returns `false`, `this.leavePowerToken` is set to `false` and causes the **No** radio to be preselected:

![screen1](https://user-images.githubusercontent.com/22304202/85996468-16e60e80-ba05-11ea-8b09-ef94122f98b1.png)

If `canLeavePowerToken()` returns `true`, `this.leavePowerToken` is set to `undefined` which forces the player to actively make a decision:

![screen2](https://user-images.githubusercontent.com/22304202/85996117-c4572300-ba01-11ea-84bc-5d8196bb6025.PNG)

If **Confirm** is clicked without a decision, an alert is shown, which seemed to be better to me than disabling Confirm:

![screen3](https://user-images.githubusercontent.com/22304202/85998390-0b95e180-ba0b-11ea-8a1d-802264c94bfc.PNG)
