### PR TITLE
Notify the owner of the game when lobby is full and game is ready to be started

### DIFF
--- a/agot-bg-game-server/src/common/EntireGame.ts
+++ b/agot-bg-game-server/src/common/EntireGame.ts
@@ -31,6 +31,10 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
     // Client-side callback fired whenever the current GameState changes.
     onClientGameStateChange: (() => void) | null;
 
+    get owner(): User | null {
+        return this.users.tryGet(this.ownerUserId, null);
+    }
+
     constructor(id: string, ownerId: string, name: string) {
         super(null);
         this.id = id;

--- a/agot-bg-game-server/src/common/lobby-game-state/LobbyGameState.ts
+++ b/agot-bg-game-server/src/common/lobby-game-state/LobbyGameState.ts
@@ -141,6 +141,11 @@ export default class LobbyGameState extends GameState<EntireGame> {
                 this.lobbyHouses.get(hid),
                 this.entireGame.users.get(uid)
             ]));
+
+            if (this.entireGame.onClientGameStateChange) {
+                // Fake a game state change to play a sound also in case lobby is full
+                this.entireGame.onClientGameStateChange();
+            }
         }
     }
 
@@ -171,7 +176,12 @@ export default class LobbyGameState extends GameState<EntireGame> {
     }
 
     getWaitedUsers(): User[] {
-        return [];
+        const owner = this.entireGame.owner;
+        if (!owner || !this.canStartGame(owner).success) {
+            return [];
+        }
+
+        return [owner];
     }
 
     serializeToClient(_admin: boolean, _user: User | null): SerializedLobbyGameState {


### PR DESCRIPTION
Closes #713

Note: I don't trigger a fake `onGameStateChanged()` when game settings are changed (which possibly also lead to full lobby) as this can only be done by the owner and I guess we don't need the sound in that case.