### PR TITLE
Add a scrollbar to the map

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -75,6 +75,7 @@ interface IngameComponentProps {
 export default class IngameComponent extends Component<IngameComponentProps> {
     mapControls: MapControls = new MapControls();
     @observable currentOpenedTab = "chat";
+    @observable height: number;
 
     get game(): Game {
         return this.props.gameState.game;
@@ -356,7 +357,7 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                     </Row>
                 </Col>
                 <Col xs="auto">
-                    <div>
+                    <div style={{height: this.height - 90, overflowY: "scroll"}}>
                         <MapComponent
                             gameClient={this.props.gameClient}
                             ingameGameState={this.props.gameState}
@@ -611,4 +612,17 @@ export default class IngameComponent extends Component<IngameComponentProps> {
             <VoteComponent key={v.id} vote={v} gameClient={this.props.gameClient} ingame={this.props.gameState} />
         ));
     }
+
+    componentDidMount(): void {
+        this.height = window.innerHeight;
+        window.addEventListener('resize', this.handleResize);
+    }
+
+    componentWillUnmount(): void {
+        window.removeEventListener('resize', this.handleResize);
+    }
+
+    handleResize = () => {
+        this.height = window.innerHeight;
+    };
 }


### PR DESCRIPTION
Relates to #622 

I tried `react-zoom-pan-pinch` but I was not able to set it up correctly for mobile. In the simulator it rendered the Action Panel inside the map, without the zoom-pan-pinch it doesn't. In addition I also didn't manage to enable a simple scroll inside the pan. I was able to zoom the map but when I scrolled to the bottom of the map it always jumped back to the top after releasing the mouse.

So I came up with this PR which gives a simple scrollbar to the map:
![image](https://user-images.githubusercontent.com/22304202/89765999-b368f980-daf7-11ea-90f3-cbf70b735575.png)

So I simply set the `height` of the map container to `window.height - offsetOfTitleHeader (empirically)` when browser resizes and apply a scrollbar when the content overflows this container. This should also work for the current mobile view.

All in all this PR should improve the Ux for playing southern houses as they can now scroll to their territories and still see the Action panel and the GameLog/Chat.
