### PR TITLE
Highlight the attacking army during combat

### DIFF
--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -187,6 +187,9 @@ export default class MapComponent extends Component<MapComponentProps> {
                                     "unit-icon hover-weak-outline",
                                     {
                                         "medium-outline hover-strong-outline": property.highlight.active
+                                    },
+                                    {
+                                        "attacking-army-highlight": property.highlight.color == "red"
                                     }
                                 )}
                                 style={{

--- a/agot-bg-game-server/src/client/MapControls.ts
+++ b/agot-bg-game-server/src/client/MapControls.ts
@@ -2,11 +2,11 @@ import Region from "../common/ingame-game-state/game-data-structure/Region";
 import Unit from "../common/ingame-game-state/game-data-structure/Unit";
 import {observable} from "mobx";
 import PartialRecursive from "../utils/PartialRecursive";
-import { ReactNode, ReactElement } from "react";
+import { ReactElement } from "react";
 
 interface HighlightProperties {
     active: boolean;
-    color: "white" | "yellow";
+    color: "white" | "yellow" | "red";
 }
 
 export interface RegionOnMapProperties {

--- a/agot-bg-game-server/src/client/game-state-panel/CombatComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/CombatComponent.tsx
@@ -28,13 +28,15 @@ import CancelHouseCardAbilitiesComponent from "./house-card-abilities/CancelHous
 import Col from "react-bootstrap/Col";
 import CombatInfoComponent from "../CombatInfoComponent";
 import Region from "../../common/ingame-game-state/game-data-structure/Region";
-import { RegionOnMapProperties } from "../MapControls";
+import { RegionOnMapProperties, UnitOnMapProperties } from "../MapControls";
 import PartialRecursive from "../../utils/PartialRecursive";
 import _ from "lodash";
+import Unit from "../../common/ingame-game-state/game-data-structure/Unit";
 
 @observer
 export default class CombatComponent extends Component<GameStateComponentProps<CombatGameState>> {
     modifyRegionsOnMapCallback: any;
+    modifyUnitsOnMapCallback: any;
 
     get combatGameState(): CombatGameState {
         return this.props.gameState;
@@ -103,18 +105,37 @@ export default class CombatComponent extends Component<GameStateComponentProps<C
     }
 
     modifyRegionsOnMap(): [Region, PartialRecursive<RegionOnMapProperties>][] {
-        // Highlight the embattled are in yellow
+        // Highlight the embattled area in yellow
         return [[
             this.props.gameState.defendingRegion,
             {highlight: {active: true, color: "yellow"}}
         ]];
     }
 
+    modifyUnitsOnMap(): [Unit, PartialRecursive<UnitOnMapProperties>][] {
+        const authenticatedPlayer = this.props.gameClient.authenticatedPlayer;
+
+        // Highlight the attacking army in red
+        // We just hightlight the attacking army until PostCombatGameState for combatants
+        // as during PostCombat some effects will highlight units for selection
+        // for winner and loser (e.g. Retreat, Renly Baratheon, Ilyn Payn, ToB skull, etc.)
+        if (this.props.gameState.childGameState instanceof DeclareSupportGameState
+            || this.props.gameState.childGameState instanceof ChooseHouseCardGameState
+            || this.props.gameState.childGameState instanceof UseValyrianSteelBladeGameState
+            // But we can highlight the attacking army for non combatants during the whole combat phase
+            || (authenticatedPlayer && !this.props.gameState.houseCombatDatas.keys.includes(authenticatedPlayer.house))) {
+            return this.props.gameState.attackingArmy.map(u => ([u, {highlight: {active: false, color: "red"}}]));
+        }
+        return [];
+    }
+
     componentDidMount(): void {
         this.props.mapControls.modifyRegionsOnMap.push(this.modifyRegionsOnMapCallback = () => this.modifyRegionsOnMap());
+        this.props.mapControls.modifyUnitsOnMap.push(this.modifyUnitsOnMapCallback = () => this.modifyUnitsOnMap());
     }
 
     componentWillUnmount(): void {
         _.pull(this.props.mapControls.modifyRegionsOnMap, this.modifyRegionsOnMapCallback);
+        _.pull(this.props.mapControls.modifyUnitsOnMap, this.modifyUnitsOnMapCallback);
     }
 }

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -259,6 +259,15 @@ filter: drop-shadow(6px 6px 6px $strong-outline) drop-shadow(-6px -6px 6px $stro
 transition: all 0.12s linear;
 }
 
+$attacking-army-outline: rgba(red, 1.0);
+.attacking-army-highlight {
+  filter: drop-shadow(4px 4px 4px $attacking-army-outline) drop-shadow(-4px -4px 4px $attacking-army-outline);
+}
+
+.attacking-army-highlight:hover {
+  filter: drop-shadow(4px 4px 4px $attacking-army-outline) drop-shadow(-4px -4px 4px $attacking-army-outline);
+}
+
 $wildling-outline: rgba(#f8ff00, 0.5);
 .wildling-highlight {
   filter: drop-shadow(1px 1px 3px $wildling-outline) drop-shadow(-1px -1px 3px $wildling-outline);


### PR DESCRIPTION
Partially solves #654. Instead of physically moving the army to the target region highlighting the attacking army during combat makes the combat even more clear without checking game log. Unfortunately I was not able to set the `$outline-color` var in the css with the value from `modifiedUnitOnMapProperties.highlight.color`. So I hacked this scenario by defining a special `highlight-attacking-army` css prop. Any ideas to do it smarter are welcome.

Previews:
![image](https://user-images.githubusercontent.com/22304202/90027961-6765b280-dcb9-11ea-9955-c7d1d4b30b92.png)
![image](https://user-images.githubusercontent.com/22304202/90027983-6cc2fd00-dcb9-11ea-810b-a11f52763b99.png)
