### PR TITLE
Improve Ux for Preemptive Raid

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/BiddingComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/BiddingComponent.tsx
@@ -2,7 +2,6 @@ import {observer} from "mobx-react";
 import BiddingGameState, {BiddingGameStateParent} from "../../common/ingame-game-state/westeros-game-state/bidding-game-state/BiddingGameState";
 import {Component, ReactNode} from "react";
 import * as React from "react";
-import {observable} from "mobx";
 import GameStateComponentProps from "./GameStateComponentProps";
 import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
@@ -11,14 +10,16 @@ import Player from "../../common/ingame-game-state/Player";
 
 @observer
 export default class BiddingComponent<ParentGameState extends BiddingGameStateParent> extends Component<GameStateComponentProps<BiddingGameState<ParentGameState>>> {
-    @observable powerTokensToBid = 0;
-
     get gameState(): BiddingGameState<ParentGameState> {
         return this.props.gameState;
     }
 
     get authenticatedPlayer(): Player | null {
         return this.props.gameClient.authenticatedPlayer;
+    }
+
+    get powerTokensToBid(): number {
+        return this.gameState.powerTokensToBid;
     }
 
     get biddenPowerTokens(): number {
@@ -34,7 +35,7 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
     constructor(props: GameStateComponentProps<BiddingGameState<ParentGameState>>) {
         super(props);
 
-        this.powerTokensToBid = Math.max(this.biddenPowerTokens, 0);
+        this.gameState.powerTokensToBid = Math.max(this.biddenPowerTokens, 0);
     }
 
     render(): ReactNode {
@@ -51,7 +52,9 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
                                         min={0}
                                         max={this.authenticatedPlayer.house.powerTokens}
                                         value={this.powerTokensToBid}
-                                        onChange={e => this.changePowerTokensToBid(parseInt(e.target.value))}
+                                        onChange={e => {
+                                            this.gameState.powerTokensToBid = parseInt(e.target.value);
+                                        }}
                                         disabled={this.authenticatedPlayer.house.powerTokens==0}
                                     />
                                 </Col>
@@ -77,10 +80,6 @@ export default class BiddingComponent<ParentGameState extends BiddingGameStatePa
                 </Col>
             </>
         );
-    }
-
-    changePowerTokensToBid(count: number): void {
-        this.powerTokensToBid = count;
     }
 
     bid(powerTokens: number): void {

--- a/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
@@ -44,6 +44,7 @@ import TheHordeDescendsNightsWatchVictoryGameState
 import TheHordeDescendsNightsWatchVictoryComponent from "./TheHordeDescendsNightsWatchVictoryComponent";
 import ListGroupItem from "react-bootstrap/ListGroupItem";
 import WildlingCardComponent from "../utils/WildlingCardComponent";
+import joinReactNodes from "../../../client/utils/joinReactNodes";
 
 @observer
 export default class WildlingsAttackComponent extends Component<GameStateComponentProps<WildlingsAttackGameState>> {
@@ -64,7 +65,7 @@ export default class WildlingsAttackComponent extends Component<GameStateCompone
                     <Row>
                         {this.props.gameState.childGameState instanceof BiddingGameState && (
                             <Col xs={12}>
-                                All houses bid Power tokens to overcome the Wildlings attack!
+                                <strong>All houses</strong>{this.props.gameState.excludedHouses.length >0 && (<> except {joinReactNodes(this.props.gameState.excludedHouses.map(h => <strong key={h.id}>{h.name}</strong>), ", ")}</>)} bid Power tokens to overcome the Wildlings attack!
                             </Col>
                         )}
                         {renderChildGameState<WildlingsAttackGameState>(this.props, [

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
@@ -27,6 +27,7 @@ import MammothRidersNightsWatchVictoryGameState, {SerializedMammothRidersNightsW
 import TheHordeDescendsWildlingVictoryGameState, {SerializedTheHordeDescendsWildlingVictoryGameState} from "./the-horde-descends-wildling-victory-game-state/TheHordeDescendsWildlingVictoryGameState";
 import TheHordeDescendsNightsWatchVictoryGameState, {SerializedTheHordeDescendsNightsWatchVictoryGameState} from "./the-horde-descends-nights-watch-victory-game-state/TheHordeDescendsNightsWatchVictoryGameState";
 import IngameGameState from "../../IngameGameState";
+import { observable } from "mobx";
 
 export default class WildlingsAttackGameState extends GameState<WesterosGameState,
     BiddingGameState<WildlingsAttackGameState> | SimpleChoiceGameState | PreemptiveRaidWildlingVictoryGameState
@@ -36,7 +37,8 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
     | MammothRidersWildlingVictoryGameState | MammothRidersNightsWatchVictoryGameState
     | TheHordeDescendsWildlingVictoryGameState | TheHordeDescendsNightsWatchVictoryGameState
 > {
-    participatingHouses: House[];
+    @observable  participatingHouses: House[];
+    
     // This field is null before the bidding phase is over,
     // as the wildling card will be drawn after the bidding phase is over.
     wildlingCard: WildlingCard | null;
@@ -44,6 +46,10 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
     _highestBidder: House | null;
     _lowestBidder: House | null;
     biddingResults: [number, House[]][] | null;
+
+    get excludedHouses(): House[] {
+        return _.difference(this.game.houses.values, this.participatingHouses);
+    }
 
     get totalBid(): number {
         if (this.biddingResults == null) {

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -14,10 +14,10 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | MoveUnits | CombatChangeArmy
     | UnitsWounded | ChangeCombatHouseCard | BeginSeeTopWildlingCard
     | RavenOrderReplaced | RevealTopWildlingCard | HideTopWildlingCard | ProceedWesterosCard | ChangeGarrison
-    | BidDone | GameStateChange | SupplyAdjusted
+    | BiddingBegin | BidDone | BiddingNextTrack | GameStateChange | SupplyAdjusted
     | ChangeControlPowerToken | ChangePowerToken | ChangeWildlingStrength | AddGameLog | RevealWildlingCard
     | RemoveUnits | AddUnits | ChangeTracker | ActionPhaseChangeOrder | ChangeStateHouseCard
-    | SettingsChanged | ChangeValyrianSteelBladeUse | BiddingNextTrack | NewPrivateChatRoom | GameSettingsChanged
+    | SettingsChanged | ChangeValyrianSteelBladeUse |  NewPrivateChatRoom | GameSettingsChanged
     | UpdateWesterosDecks | UpdateConnectionStatus | VoteStarted | VoteCancelled | VoteDone | PlayerReplaced
     | CrowKillersStepChanged;
 
@@ -143,6 +143,10 @@ interface HideTopWildlingCard {
 interface ProceedWesterosCard {
     type: "proceed-westeros-card";
     currentCardI: number;
+}
+
+interface BiddingBegin {
+    type: "bidding-begin";
 }
 
 interface BidDone {


### PR DESCRIPTION
This PR refreshes the UI on a second wildlings attack after PreemptiveRaidNightwatchVictory until #569 is resolved. In addition the game now shows the excluded houses of a wildlings bidding.