### PR TITLE
Add CoK Westeros Phase Variant

### DIFF
--- a/agot-bg-game-server/src/client/GameSettingsComponent.tsx
+++ b/agot-bg-game-server/src/client/GameSettingsComponent.tsx
@@ -75,6 +75,24 @@ export default class GameSettingsComponent extends Component<GameSettingsCompone
                                 />
                             </Col>
                         </Row>
+                        <Row>
+                            <Col xs="auto">
+                                <FormCheck
+                                    id="random-houses-setting"
+                                    type="checkbox"
+                                    label={
+                                        <OverlayTrigger overlay={
+                                            <Tooltip id="random-houses-tooltip">
+                                                Players may look at the next 3 Westeros cards from each deck at any given moment of the game.
+                                            </Tooltip>}>
+                                            <label htmlFor="random-houses-setting">Enable CoK Westeros Phase Variant</label>
+                                        </OverlayTrigger>}
+                                    disabled={!this.canChangeGameSettings}
+                                    checked={this.gameSettings.cokWesterosPhase}
+                                    onChange={() => this.changeGameSettings(() => this.gameSettings.cokWesterosPhase = !this.gameSettings.cokWesterosPhase)}
+                                />
+                            </Col>
+                        </Row>
                     </>
                 )}
                 <Row>

--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -67,6 +67,7 @@ import joinReactNodes from "./utils/joinReactNodes";
 import NoteComponent from "./NoteComponent";
 import UnitType from "../common/ingame-game-state/game-data-structure/UnitType";
 import UserSettingsComponent from "./UserSettingsComponent";
+import {GameSettings} from '../common/EntireGame';
 
 interface IngameComponentProps {
     gameClient: GameClient;
@@ -81,6 +82,10 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     get game(): Game {
         return this.props.gameState.game;
+    }
+
+    get gameSettings(): GameSettings {
+        return this.props.gameState.entireGame.gameSettings;
     }
 
     get user(): User | null {
@@ -569,26 +574,45 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     private renderRemainingWesterosCards(): ReactNode {
         const remainingCards = this.game.remainingWesterosCardTypes;
+        const nextCards = this.game.nextWesterosCardNames;
 
         return <Tooltip id="remaining-westeros-cards" className="westeros-tooltip">
-            <h5 style={{textAlign: "center"}}>Remaining Westeros Cards</h5>
-            <table cellPadding="5">
-                <thead>
-                    <tr>
-                        {remainingCards.map((_, i) =>
-                            <th key={"westeros-deck-" + i + "-header"} style={{textAlign: "center"}}>Deck {i + 1}</th>)}
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        {remainingCards.map((rc, i) =>
-                            <td key={"westeros-deck-" + i + "-data"}>
-                                {rc.entries.map(([wc, count], j) => <div key={"westeros-deck-" + i + "-" + j + "-data"}><small>{wc.name}</small> ({count})</div>)}
-                            </td>
+            {this.gameSettings.cokWesterosPhase && (
+                <>
+                    <Row className='mt-0'>
+                        <Col>
+                            <h5 className='text-center'>Next Westeros Cards</h5>
+                        </Col>
+                    </Row>
+                    <Row>
+                        {nextCards.map((_, i) =>
+                            <Col key={"westeros-deck-" + i + "-header"} className='text-center'>Deck {i + 1}</Col>)}
+                    </Row>
+                    <Row>
+                        {nextCards.map((wd, i) =>
+                            <Col key={"westeros-deck-" + i + "-data"}>
+                                {wd.map((wc, j) => <div key={"westeros-deck-" + i + "-" + j + "-data"}><small>{wc}</small></div>)}
+                            </Col>
                         )}
-                    </tr>
-                </tbody>
-            </table>
+                    </Row>
+                </>
+            )}
+            <Row className='mt-0'>
+                <Col>
+                    <h5 className='text-center'>Remaining Westeros Cards</h5>
+                </Col>
+            </Row>
+            <Row>
+                {remainingCards.map((_, i) =>
+                    <Col key={"westeros-deck-" + i + "-header"} style={{textAlign: "center"}}>Deck {i + 1}</Col>)}
+            </Row>
+            <Row>
+                {remainingCards.map((rc, i) =>
+                    <Col key={"westeros-deck-" + i + "-data"}>
+                        {rc.entries.map(([wc, count], j) => <div key={"westeros-deck-" + i + "-" + j + "-data"}><small>{wc.name}</small> ({count})</div>)}
+                    </Col>
+                )}
+            </Row>
         </Tooltip>;
     }
 
@@ -599,7 +623,7 @@ export default class IngameComponent extends Component<IngameComponentProps> {
     onNewPrivateChatRoomClick(p: Player): void {
         const users = _.sortBy([this.props.gameClient.authenticatedUser as User, p.user], u => u.id);
 
-        if (!this.props.gameState.entireGame.privateChatRoomsIds.has(users[0]) || !this.props.gameState.entireGame.privateChatRoomsIds.get(users[0]).has(users[1])) {
+        if (!this.props.gameState.entireGame.privateChatRoomsIds.has(users[0]) || !this.props.gameState.entireGame.privateChatRoomsIds.get(users[0]).has(users[1])) {
             // Create a new chat room for this player
             this.props.gameState.entireGame.sendMessageToServer({
                 type: "create-private-chat-room",

--- a/agot-bg-game-server/src/common/EntireGame.ts
+++ b/agot-bg-game-server/src/common/EntireGame.ts
@@ -20,7 +20,7 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
     ownerUserId: string;
     name: string;
 
-    @observable gameSettings: GameSettings = {pbem: false, setupId: "base-game", playerCount: 6, randomHouses: false};
+    @observable gameSettings: GameSettings = {pbem: false, setupId: "base-game", playerCount: 6, randomHouses: false, cokWesterosPhase: false};
     onSendClientMessage: (message: ClientMessage) => void;
     onSendServerMessage: (users: User[], message: ServerMessage) => void;
     onWaitedUsers: (users: User[]) => void;
@@ -159,7 +159,7 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
             const user = this.users.get(message.user);
 
             user.settings = message.settings;
-        } else if (message.type == "game-settings-changed") {
+        } else if (message.type == "game-settings-changed") {
             this.gameSettings = message.settings;
         } else if (message.type == "update-connection-status") {
             const user = this.users.get(message.user);
@@ -363,4 +363,5 @@ export interface GameSettings {
     setupId: string;
     playerCount: number;
     randomHouses: boolean;
+    cokWesterosPhase: boolean;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -39,6 +39,7 @@ export default class Game {
     structuresCountNeededToWin: number;
     maxTurns: number;
     maxPowerTokens: number;
+    revealedWesterosCards = 0;
 
     get ironThroneHolder(): House {
         return this.getTokenHolder(this.ironThroneTrack);
@@ -65,7 +66,7 @@ export default class Game {
 
         this.westerosDecks.forEach(wd => {
             const map = new BetterMap<WesterosCardType, number>();
-            wd.sort((a, b) => a.type.name.localeCompare(b.type.name)).forEach(wc => {
+            wd.slice(this.revealedWesterosCards).sort((a, b) => a.type.name.localeCompare(b.type.name)).forEach(wc => {
                 if (wc.discarded) {
                     return;
                 }
@@ -75,6 +76,16 @@ export default class Game {
                 map.set(wc.type, map.get(wc.type) + 1);
             });
             result.push(map);
+        });
+
+        return result;
+    }
+
+    get nextWesterosCardNames(): string[][] {
+        const result: string[][] = [];
+
+        this.westerosDecks.forEach(wd => {
+            result.push(wd.slice(0, this.revealedWesterosCards).map((card) => card.type.name));
         });
 
         return result;
@@ -340,7 +351,9 @@ export default class Game {
             // without seeing the order of the cards
             westerosDecks: admin
                 ? this.westerosDecks.map(wd => wd.map(wc => wc.serializeToClient()))
-                : this.westerosDecks.map(wd => shuffle([...wd]).map(wc => wc.serializeToClient())),
+                : this.westerosDecks.map(wd => wd.slice(0, this.revealedWesterosCards)
+                    .concat(shuffle(wd.slice(this.revealedWesterosCards)))
+                    .map(wc => wc.serializeToClient())),
             // Same for the wildling deck
             wildlingDeck: admin
                 ? this.wildlingDeck.map(c => c.serializeToClient())
@@ -352,6 +365,7 @@ export default class Game {
             structuresCountNeededToWin: this.structuresCountNeededToWin,
             maxTurns: this.maxTurns,
             maxPowerTokens: this.maxPowerTokens,
+            revealedWesterosCards: this.revealedWesterosCards,
             clientNextWidllingCardId: (admin || knowsNextWildlingCard) ? this.wildlingDeck[0].id : null
         };
     }
@@ -376,6 +390,7 @@ export default class Game {
         game.structuresCountNeededToWin = data.structuresCountNeededToWin;
         game.maxTurns = data.maxTurns;
         game.maxPowerTokens = data.maxPowerTokens;
+        game.revealedWesterosCards = data.revealedWesterosCards;
         game.clientNextWildlingCardId = data.clientNextWidllingCardId;
 
         return game;
@@ -400,5 +415,6 @@ export interface SerializedGame {
     structuresCountNeededToWin: number;
     maxTurns: number;
     maxPowerTokens: number;
+    revealedWesterosCards: number;
     clientNextWidllingCardId: number | null;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
@@ -80,6 +80,8 @@ export default function createGame(entireGame: EntireGame, housesToCreate: strin
     game.supplyRestrictions = baseGameData.supplyRestrictions;
     game.maxPowerTokens = MAX_POWER_TOKENS;
 
+    game.revealedWesterosCards = entireGame.gameSettings.cokWesterosPhase ? 3 : 0;
+
     // Load tracks starting positions
     if (gameSetup.tracks && gameSetup.tracks.ironThrone) {
         game.ironThroneTrack = gameSetup.tracks.ironThrone.filter(hid => housesToCreate.includes(hid)).map(hid => game.houses.get(hid));

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/westeros-card/WinterIsComingWesterosCardType.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/westeros-card/WinterIsComingWesterosCardType.ts
@@ -12,16 +12,17 @@ export default class WinterIsComingWesterosCardType extends WesterosCardType {
             westerosDeckI: currentDeckI
         });
 
-        const deck = westerosGameState.game.westerosDecks[currentDeckI];
+        let deck = westerosGameState.game.westerosDecks[currentDeckI];
+        const dontShuffle = westerosGameState.game.revealedWesterosCards - 1;
 
         // Reset discarded state
         deck.forEach(card => { card.discarded = false; });
 
         // Shuffle the deck
-        shuffle(deck);
+        deck = deck.slice(0, dontShuffle).concat(shuffle(deck.slice(dontShuffle)));
 
         // Draw a new card from this deck ...
-        const newDrawnCard = deck.shift() as WesterosCard;
+        const newDrawnCard = deck.splice(dontShuffle, 1)[0] as WesterosCard;
 
         // ... and burry it at the bottom of the deck
         deck.push(newDrawnCard);

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/WesterosGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/WesterosGameState.ts
@@ -97,9 +97,11 @@ export default class WesterosGameState extends GameState<IngameGameState,
             this.revealedCards[i].type.executeImmediately(this, i);
         }
 
+        const revealedWCs = this.game.revealedWesterosCards;
+
         this.entireGame.broadcastToClients({
             type: "update-westeros-decks",
-            westerosDecks: this.game.westerosDecks.map(wd => shuffle([...wd]).map(wc => wc.serializeToClient()))
+            westerosDecks: this.game.westerosDecks.map(wd => wd.slice(0, revealedWCs).concat(shuffle(wd.slice(revealedWCs))).map(wc => wc.serializeToClient()))
         });
 
         this.currentCardI = -1;


### PR DESCRIPTION
With this variant enabled on the game menu, players will be able to see the top 3 cards of each westeros deck at any given point during the game.

![PR1-3](https://user-images.githubusercontent.com/17865825/96759530-903baf80-13ae-11eb-948f-5724a6f41f36.png)

![PR1-1](https://user-images.githubusercontent.com/17865825/96759283-33d89000-13ae-11eb-87b2-2d7d45cdedff.png)

Also, according to CoK Westeros Phase rules, the card 'Winter is Coming' should not change the second and third card of the revealed pile when it's resolved. Therefore, on the next turn of the above screenshot we should see that Supply is still the first card and Mustering is the second card of the 1st Westeros Deck (as per the screenshot below).

![PR1-2](https://user-images.githubusercontent.com/17865825/96759288-3509bd00-13ae-11eb-9e2f-13340e430a42.png)
