### PR TITLE
Add CoK Westeros Phase variant

### DIFF
--- a/agot-bg-game-server/src/client/GameSettingsComponent.tsx
+++ b/agot-bg-game-server/src/client/GameSettingsComponent.tsx
@@ -60,18 +60,36 @@ export default class GameSettingsComponent extends Component<GameSettingsCompone
                         <Row>
                             <Col xs="auto">
                                 <FormCheck
-                                    id="random-houses-setting"
+                                    id="westeros-phase-variant-setting"
                                     type="checkbox"
                                     label={
                                         <OverlayTrigger overlay={
                                             <Tooltip id="random-houses-tooltip">
                                                 Houses will be randomized before the game starts when this option is selected.
                                             </Tooltip>}>
-                                            <label htmlFor="random-houses-setting">Randomize houses</label>
+                                            <label htmlFor="westeros-phase-variant-setting">Randomize houses</label>
                                         </OverlayTrigger>}
                                     disabled={!this.canChangeGameSettings}
                                     checked={this.gameSettings.randomHouses}
                                     onChange={() => this.changeGameSettings(() => this.gameSettings.randomHouses = !this.gameSettings.randomHouses)}
+                                />
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col xs="auto">
+                                <FormCheck
+                                    id="random-houses-setting"
+                                    type="checkbox"
+                                    label={
+                                        <OverlayTrigger overlay={
+                                            <Tooltip id="random-houses-tooltip">
+                                                Players may look at the next 3 Westeros cards from each deck at any given moment of the game.
+                                            </Tooltip>}>
+                                            <label htmlFor="random-houses-setting">Enable CoK Westeros Phase Variant</label>
+                                        </OverlayTrigger>}
+                                    disabled={!this.canChangeGameSettings}
+                                    checked={this.gameSettings.cokWesterosPhase}
+                                    onChange={() => this.changeGameSettings(() => this.gameSettings.cokWesterosPhase = !this.gameSettings.cokWesterosPhase)}
                                 />
                             </Col>
                         </Row>

--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -67,6 +67,7 @@ import joinReactNodes from "./utils/joinReactNodes";
 import NoteComponent from "./NoteComponent";
 import UnitType from "../common/ingame-game-state/game-data-structure/UnitType";
 import UserSettingsComponent from "./UserSettingsComponent";
+import { GameSettings } from '../common/EntireGame';
 
 interface IngameComponentProps {
     gameClient: GameClient;
@@ -81,6 +82,10 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     get game(): Game {
         return this.props.gameState.game;
+    }
+
+    get gameSettings(): GameSettings {
+        return this.props.gameState.entireGame.gameSettings;
     }
 
     get user(): User | null {
@@ -569,26 +574,44 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     private renderRemainingWesterosCards(): ReactNode {
         const remainingCards = this.game.remainingWesterosCardTypes;
-
+        const nextCards = this.game.nextWesterosCardTypes;
+        
         return <Tooltip id="remaining-westeros-cards" className="westeros-tooltip">
-            <h5 style={{textAlign: "center"}}>Remaining Westeros Cards</h5>
-            <table cellPadding="5">
-                <thead>
-                    <tr>
-                        {remainingCards.map((_, i) =>
-                            <th key={"westeros-deck-" + i + "-header"} style={{textAlign: "center"}}>Deck {i + 1}</th>)}
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        {remainingCards.map((rc, i) =>
-                            <td key={"westeros-deck-" + i + "-data"}>
-                                {rc.entries.map(([wc, count], j) => <div key={"westeros-deck-" + i + "-" + j + "-data"}><small>{wc.name}</small> ({count})</div>)}
-                            </td>
-                        )}
-                    </tr>
-                </tbody>
-            </table>
+            {this.gameSettings.cokWesterosPhase && (
+                <>
+                    <Row className='mt-0'>
+                        <Col>
+                            <h5 className='text-center'>Next Westeros Cards</h5>
+                        </Col>
+                    </Row>
+                    <Row>
+                        {nextCards.map((_, i) =>
+                            <Col key={"westeros-deck-" + i + "-header"} className='text-center'>Deck {i + 1}</Col>)}
+                    </Row>
+                    <Row>
+                        {nextCards.map((wd, i) =>
+                            <Col key={"westeros-deck-" + i + "-data"}>
+                                {wd.map((wc, j) => <div key={"westeros-deck-" + i + "-" + j + "-data"}><small>{wc.name}</small></div>)}
+                            </Col>)}
+                    </Row>
+                </>
+            )}
+            <Row className='mt-0'>
+                <Col>
+                    <h5 className='text-center'>Remaining Westeros Cards</h5>
+                </Col>
+            </Row>
+            <Row>
+                {remainingCards.map((_, i) =>
+                    <Col key={"westeros-deck-" + i + "-header"} style={{ textAlign: "center" }}>Deck {i + 1}</Col>)}
+            </Row>
+            <Row>
+                {remainingCards.map((rc, i) =>
+                    <Col key={"westeros-deck-" + i + "-data"}>
+                        {rc.entries.map(([wc, count], j) => <div key={"westeros-deck-" + i + "-" + j + "-data"}><small>{wc.name}</small> ({count})</div>)}
+                    </Col>
+                )}
+            </Row>
         </Tooltip>;
     }
 

--- a/agot-bg-game-server/src/common/EntireGame.ts
+++ b/agot-bg-game-server/src/common/EntireGame.ts
@@ -20,7 +20,7 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
     ownerUserId: string;
     name: string;
 
-    @observable gameSettings: GameSettings = {pbem: false, setupId: "base-game", playerCount: 6, randomHouses: false};
+    @observable gameSettings: GameSettings = { pbem: false, setupId: "base-game", playerCount: 6, randomHouses: false, cokWesterosPhase: false };
     onSendClientMessage: (message: ClientMessage) => void;
     onSendServerMessage: (users: User[], message: ServerMessage) => void;
     onWaitedUsers: (users: User[]) => void;
@@ -363,4 +363,5 @@ export interface GameSettings {
     setupId: string;
     playerCount: number;
     randomHouses: boolean;
+    cokWesterosPhase: boolean;
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/createGame.ts
@@ -79,6 +79,8 @@ export default function createGame(entireGame: EntireGame, housesToCreate: strin
     game.structuresCountNeededToWin = baseGameData.structuresCountNeededToWin;
     game.supplyRestrictions = baseGameData.supplyRestrictions;
     game.maxPowerTokens = MAX_POWER_TOKENS;
+    
+    game.revealedWesterosCards = entireGame.gameSettings.cokWesterosPhase ? 3 : 0;
 
     // Load tracks starting positions
     if (gameSetup.tracks && gameSetup.tracks.ironThrone) {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/westeros-card/WinterIsComingWesterosCardType.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/westeros-card/WinterIsComingWesterosCardType.ts
@@ -12,16 +12,17 @@ export default class WinterIsComingWesterosCardType extends WesterosCardType {
             westerosDeckI: currentDeckI
         });
 
-        const deck = westerosGameState.game.westerosDecks[currentDeckI];
+        let deck = westerosGameState.game.westerosDecks[currentDeckI];
+        const dontShuffle = Math.max(0,westerosGameState.game.revealedWesterosCards - 1);
 
         // Reset discarded state
         deck.forEach(card => { card.discarded = false; });
 
         // Shuffle the deck
-        shuffle(deck);
+        deck = deck.slice(0, dontShuffle).concat(shuffle(deck.slice(dontShuffle)));
 
         // Draw a new card from this deck ...
-        const newDrawnCard = deck.shift() as WesterosCard;
+        const newDrawnCard = deck.splice(dontShuffle, 1)[0] as WesterosCard;
 
         // ... and burry it at the bottom of the deck
         deck.push(newDrawnCard);

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/WesterosGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/WesterosGameState.ts
@@ -97,9 +97,12 @@ export default class WesterosGameState extends GameState<IngameGameState,
             this.revealedCards[i].type.executeImmediately(this, i);
         }
 
+        const revealedWCs = this.game.revealedWesterosCards;
+
         this.entireGame.broadcastToClients({
             type: "update-westeros-decks",
-            westerosDecks: this.game.westerosDecks.map(wd => shuffle([...wd]).map(wc => wc.serializeToClient()))
+            westerosDecks: this.game.westerosDecks.map(wd => wd.slice(0, revealedWCs)
+                .concat(shuffle(wd.slice(revealedWCs))).map(wc => wc.serializeToClient()))
         });
 
         this.currentCardI = -1;


### PR DESCRIPTION
(Made a new PR with the correct branch, now with only 1 commit)

With this variant enabled on the game menu, players will be able to see the top 3 cards of each westeros deck at any given point during the game.

![PR1-3](https://user-images.githubusercontent.com/17865825/96759530-903baf80-13ae-11eb-948f-5724a6f41f36.png)

![PR1-1](https://user-images.githubusercontent.com/17865825/96759283-33d89000-13ae-11eb-87b2-2d7d45cdedff.png)

Also, according to CoK Westeros Phase rules, the card 'Winter is Coming' should not change the second and third card of the revealed pile when it's resolved. Therefore, on the next turn of the above screenshot we should see that Supply is still the first card and Mustering is the second card of the 1st Westeros Deck (as per the screenshot below).

![PR1-2](https://user-images.githubusercontent.com/17865825/96759288-3509bd00-13ae-11eb-9e2f-13340e430a42.png)
