### PR TITLE
Update Wildlings Attack text to reflect current wildling strength

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
@@ -65,10 +65,10 @@ export default class WildlingsAttackComponent extends Component<GameStateCompone
                     <Row>
                         {this.props.gameState.childGameState instanceof BiddingGameState && (
                             <Col xs={12}>
-                                <strong>All houses</strong>{this.props.gameState.excludedHouses.length >0 && 
+                                <b>All houses</b>{this.props.gameState.excludedHouses.length >0 && 
                                 (<> except {joinReactNodes(this.props.gameState.excludedHouses.map(h => 
-                                <strong key={h.id}>{h.name}</strong>), ", ")}</>)} bid Power tokens to overcome the 
-                                Wildlings attacking with <strong>{this.props.gameState.game.wildlingStrength} strength</strong>!
+                                <b key={h.id}>{h.name}</b>), ", ")}</>)} bid Power tokens to overcome the 
+                                Wildlings which are attacking with a strength of <b>{this.props.gameState.game.wildlingStrength}</b>!
                             </Col>
                         )}
                         {renderChildGameState<WildlingsAttackGameState>(this.props, [

--- a/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
@@ -65,7 +65,10 @@ export default class WildlingsAttackComponent extends Component<GameStateCompone
                     <Row>
                         {this.props.gameState.childGameState instanceof BiddingGameState && (
                             <Col xs={12}>
-                                <strong>All houses</strong>{this.props.gameState.excludedHouses.length >0 && (<> except {joinReactNodes(this.props.gameState.excludedHouses.map(h => <strong key={h.id}>{h.name}</strong>), ", ")}</>)} bid Power tokens to overcome the Wildlings attack!
+                                <strong>All houses</strong>{this.props.gameState.excludedHouses.length >0 && 
+                                (<> except {joinReactNodes(this.props.gameState.excludedHouses.map(h => 
+                                <strong key={h.id}>{h.name}</strong>), ", ")}</>)} bid Power tokens to overcome the 
+                                Wildlings attacking with <strong>{this.props.gameState.game.wildlingStrength} strength</strong>!
                             </Col>
                         )}
                         {renderChildGameState<WildlingsAttackGameState>(this.props, [


### PR DESCRIPTION
Fixes #745 

All I did was add two more words at the end of the 'Wildlings Attack' text, so it would reflect the new strength during bidding. The wildling strength indicator on the left side was already updating properly.
![image](https://user-images.githubusercontent.com/17865825/96916904-91d4a880-147e-11eb-99a9-4f261b34d16d.png)
