### PR TITLE
Remove the influence icons from board when CoK started

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/clash-of-kings-game-state/ClashOfKingsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/clash-of-kings-game-state/ClashOfKingsGameState.ts
@@ -21,6 +21,26 @@ export default class ClashOfKingsGameState extends GameState<WesterosGameState, 
     }
 
     firstStart(): void {
+        // Reset Iron Throne track but keep current holder to allow resolving ties
+        this.entireGame.broadcastToClients({
+            type: "change-tracker",
+            trackerI: 0,
+            tracker: [this.game.ironThroneTrack[0].id]
+        });
+
+        // Reset Fiefdoms and Kings Court completely
+        this.entireGame.broadcastToClients({
+            type: "change-tracker",
+            trackerI: 1,
+            tracker: []
+        });
+
+        this.entireGame.broadcastToClients({
+            type: "change-tracker",
+            trackerI: 2,
+            tracker: []
+        });
+
         this.proceedNextTrack();
     }
 


### PR DESCRIPTION
Closes #286 

This PR at least removes the icons. Drawing a placeholder for the open positions is a bit more complex and is not worth the effort right now.