### PR TITLE
Improve Mustering Ux

### DIFF
--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -194,6 +194,9 @@ export default class MapComponent extends Component<MapComponentProps> {
                                     {
                                         "unit-highlight-yellow": property.highlight.color == "yellow"
                                     },
+                                    {
+                                        "unit-highlight-green": property.highlight.color == "green"
+                                    },
                                 )}
                                 style={{
                                     backgroundImage: `url(${unitImages.get(u.allegiance.id).get(u.upgradedType ? u.upgradedType.id : u.type.id)})`,

--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -144,7 +144,7 @@ export default class MapComponent extends Component<MapComponentProps> {
 
     renderUnits(): ReactNode {
         const propertiesForUnits = this.getModifiedPropertiesForEntities<Unit, UnitOnMapProperties>(
-            _.flatMap(this.props.ingameGameState.world.regions.values.map(r => r.units.values)),
+            _.flatMap(this.props.ingameGameState.world.regions.values.map(r => r.allUnits)),
             this.props.mapControls.modifyUnitsOnMap,
             {highlight: {active: false, color: "white"}, onClick: null}
         );
@@ -156,7 +156,7 @@ export default class MapComponent extends Component<MapComponentProps> {
                 className="units-container"
                 style={{left: r.unitSlot.point.x, top: r.unitSlot.point.y, width: r.unitSlot.width, flexWrap: r.type == land ? "wrap-reverse" : "wrap"}}
             >
-                {r.units.values.map(u => {
+                {r.allUnits.map(u => {
                     const property = propertiesForUnits.get(u);
 
                     let opacity: number;
@@ -190,10 +190,13 @@ export default class MapComponent extends Component<MapComponentProps> {
                                     },
                                     {
                                         "attacking-army-highlight": property.highlight.color == "red"
-                                    }
+                                    },
+                                    {
+                                        "unit-highlight-yellow": property.highlight.color == "yellow"
+                                    },
                                 )}
                                 style={{
-                                    backgroundImage: `url(${unitImages.get(u.allegiance.id).get(u.type.id)})`,
+                                    backgroundImage: `url(${unitImages.get(u.allegiance.id).get(u.upgradedType ? u.upgradedType.id : u.type.id)})`,
                                     opacity: opacity,
                                     transform: transform
                                 }}

--- a/agot-bg-game-server/src/client/MapControls.ts
+++ b/agot-bg-game-server/src/client/MapControls.ts
@@ -6,7 +6,7 @@ import { ReactElement } from "react";
 
 interface HighlightProperties {
     active: boolean;
-    color: "white" | "yellow" | "red";
+    color: "white" | "yellow" | "red" | "green";
 }
 
 export interface RegionOnMapProperties {

--- a/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
@@ -3,39 +3,45 @@ import PlayerMusteringGameState, {
     PlayerMusteringType
 } from "../../common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState";
 import {observer} from "mobx-react";
-import React, {Component, ReactNode} from "react";
+import React, {Component, ReactElement, ReactNode} from "react";
 import Region from "../../common/ingame-game-state/game-data-structure/Region";
 import BetterMap from "../../utils/BetterMap";
 import {observable} from "mobx";
 import House from "../../common/ingame-game-state/game-data-structure/House";
 import * as _ from "lodash";
-import {Button} from "react-bootstrap";
+import {Button, OverlayTrigger, Popover} from "react-bootstrap";
 import GameStateComponentProps from "./GameStateComponentProps";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import classNames from "classnames";
 import {OrderOnMapProperties, RegionOnMapProperties, UnitOnMapProperties} from "../MapControls";
 import PartialRecursive from "../../utils/PartialRecursive";
 import Unit from "../../common/ingame-game-state/game-data-structure/Unit";
 
 @observer
 export default class PlayerMusteringComponent extends Component<GameStateComponentProps<PlayerMusteringGameState>> {
-    @observable selectedRegion: Region | null;
     @observable musterings = new BetterMap<Region, Mustering[]>();
 
     modifyRegionsOnMapCallback: any;
-    modifyOrdersOnMapCallback: any;
     modifyUnitsOnMapCallback: any;
+    modifyOrdersOnMapCallback: any;
 
     get house(): House {
         return this.props.gameState.house;
+    }
+
+    get isStarredConsolidatePowerMusteringType(): boolean {
+        return this.props.gameState.isStarredConsolidatePowerMusteringType;
+    }
+
+    get doesControlCurrentHouse(): boolean {
+        return this.props.gameClient.doesControlHouse(this.house);
     }
 
     render(): ReactNode {
         return (
             <>
                 <Col xs={12}>
-                    {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER ? (
+                    {this.isStarredConsolidatePowerMusteringType ? (
                         <>House <b>{this.house.name}</b> must resolve one of its Consolidate Power Orders.</>
                     ) : this.props.gameState.type == PlayerMusteringType.MUSTERING_WESTEROS_CARD ? (
                         <>Players can muster units in their controlled castles and fortresses.</>
@@ -43,17 +49,17 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                         <>House <b>{this.house.name}</b> can muster units in one of their controlled castles or fortresses.</>
                     )}
                 </Col>
-                {this.props.gameClient.doesControlHouse(this.house) ? (
+                {this.doesControlCurrentHouse ? (
                     <>
                         {this.musterings.size > 0 && (
                             <Col xs={12}>
-                                {this.musterings.entries.map(([region, musterings]) => (
-                                    <div key={region.id}>
-                                        From <b>{region.name}</b>:
+                                {this.musterings.entries.map(([r, musterings]) => (
+                                    <div key={r.id}>
+                                        From <b>{r.name}</b>
                                         <ul>
                                             {musterings.map(({region, from, to}, i) => (
                                                 <li onClick={() => this.removeMustering(musterings, i)} key={i}>
-                                                    {from ? "Upgrading to " : "Recruiting "} a {to.name} in {region.name}
+                                                    {from ? "Upgrading to " : "Recruiting "} a {to.name}{r != region && ("in " + region.name)}
                                                 </li>
                                             ))}
                                         </ul>
@@ -61,51 +67,25 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                                 ))}
                             </Col>
                         )}
-                        {!(this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER && this.musterings.size > 0) && (
+                        {(this.musterings.size == 0 || (this.props.gameState.type == PlayerMusteringType.MUSTERING_WESTEROS_CARD && this.props.gameState.anyUsablePointsLeft(this.musterings))) && (
                             <Col xs={12}>
-                                {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER ?
-                                    <>Click on a Consolidate Power Order token to resolve it.</>
+                                {this.isStarredConsolidatePowerMusteringType ?
+                                    <>Click on a Consolidate Power Order token to resolve it for gaining Power tokens or click on a region with a
+                                    Special Consolidate Power Order token to initiate a recruitment from there.</>
                                   : <>Click on a region to initiate a recruitment from there.</>}
                             </Col>
                         )}
-                        {this.selectedRegion && (
-                            <>
-                                {this.selectedRegion.hasStructure && this.checkStarredConsolidatePower(this.selectedRegion) && this.props.gameState.getValidMusteringRulesForRegion(this.selectedRegion, this.musterings).length > 0 && (
-                                    <>
-                                        <Col xs={12}>
-                                            From <b>{this.selectedRegion.name}</b>, you can ({this.props.gameState.getPointsLeft(this.selectedRegion, this.musterings)} mustering points left):
-                                        </Col>
-                                        <Col xs={12}>
-                                            <Row>
-                                                {this.props.gameState.getValidMusteringRules(this.selectedRegion, this.musterings).map(({region, rules}) => (
-                                                    rules.map((r, i) => (
-                                                        <Col xs="auto" key={region.id + "-" + i}>
-                                                            <Button onClick={() => this.addMustering(r)}>
-                                                                [{r.cost}] {r.from ? "Upgrade to " : "Recruit "} a {r.to.name} in {region.name}
-                                                            </Button>
-                                                        </Col>
-                                                    ))
-                                                ))}
-                                            </Row>
-                                        </Col>
-                                    </>
-                                )}
-                            </>
-                        )}
                         <Col xs={12}>
                             <Row className="justify-content-center">
-                                {(!this.selectedRegion || this.checkStarredConsolidatePower(this.selectedRegion)) && (
+                                {(!this.isStarredConsolidatePowerMusteringType || (this.musterings.size > 0 && this.musterings.values[0].length > 0)) && (
                                  <Col xs="auto">
                                     <Button disabled={!this.canSubmit()} onClick={() => this.submit()}>Submit</Button>
                                 </Col>)}
-                                {this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER && this.selectedRegion &&
-                                    this.props.gameState.hasConsolidatePowerOrder(this.selectedRegion) &&
-                                    (<Col xs="auto" className={classNames({"invisible": this.selectedRegion == null})}>
-                                        <Button
-                                                onClick={() => this.submitForPT()}
-                                                disabled={this.selectedRegion == null || (this.musterings.size > 0 && this.musterings.entries[0][1].length > 0)}
-                                            >
-                                                {this.getPowerTokenButtonText()}
+                                {this.isStarredConsolidatePowerMusteringType &&
+                                    this.musterings.size == 1 && this.musterings.values[0].length == 0 &&
+                                    (<Col xs="auto">
+                                        <Button onClick={() => this.submitForPT()}>
+                                            {this.getPowerTokenButtonText()}
                                         </Button>
                                     </Col>)
                                 }
@@ -130,27 +110,56 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
         );
     }
 
+    private hasConsolidatePowerOrder(region: Region | null): boolean {
+        if (!region) {
+            return false;
+        }
+
+        if (this.props.gameState.getConsolidatePowerOrder(region)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    hasStarredConsolidatePowerOrder(region: Region | null): boolean {
+        if (!region) {
+            return false;
+        }
+
+        const order = this.props.gameState.getConsolidatePowerOrder(region);
+
+        if (order) {
+            return order.type.starred;
+        }
+
+        return false;
+    }
+
     private removeMustering(musterings: Mustering[], i: number): void {
         const removedMustering = musterings.splice(i, 1)[0];
-        const region = removedMustering.region;
 
         if (removedMustering.affectedUnit) {
             if (removedMustering.from) {
                 removedMustering.affectedUnit.upgradedType = undefined;
             } else {
-                region.newUnits = region.newUnits.filter(u => u != removedMustering.affectedUnit);
+                removedMustering.region.newUnits = removedMustering.region.newUnits.filter(u => u != removedMustering.affectedUnit);
             }
         }
 
+        this.removeEmptyMusterings();
+    }
+
+    private removeEmptyMusterings() {
         this.musterings.keys.forEach(r => {
-           const mustering = this.musterings.get(r);
-           if (mustering.length == 0) {
-               this.musterings.delete(r);
-           }
+            const mustering = this.musterings.get(r);
+            if (mustering.length == 0) {
+                this.musterings.delete(r);
+            }
         });
     }
 
-    canSubmit(): boolean {
+    private canSubmit(): boolean {
         switch (this.props.gameState.type) {
             case PlayerMusteringType.MUSTERING_WESTEROS_CARD:
                 return true;
@@ -159,36 +168,38 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                 // If he can't use it for muster, he has to use it for gaining PTs
                 return this.musterings.size > 0 && this.musterings.entries[0][1].length > 0;
             case PlayerMusteringType.THE_HORDE_DESCENDS_WILDLING_CARD:
-                return true;
+                return this.musterings.size <= 1;
         }
     }
 
-    addMustering(rule: Mustering): void {
-        if (this.selectedRegion == null) {
-            return;
-        }
-
-        const musterings: Mustering[] = this.musterings.tryGet(this.selectedRegion, []);
+    private addMustering(initiatingRegion: Region, rule: Mustering): void {
+        const musterings: Mustering[] = this.musterings.tryGet(initiatingRegion, []);
 
         if (rule.from) {
-            rule.affectedUnit = this.props.gameState.getUnitsLeftToUpgrade(this.musterings, rule.region)[0];
+            const potentialUnit = this.props.gameState.getPotentialUnitForUpgrading(this.musterings, rule.region, rule.from.type);
+            if (!potentialUnit) {
+                throw new Error("An upgrade was added but there is no unit to upgrade");
+            }
+            rule.affectedUnit = potentialUnit;
             rule.affectedUnit.upgradedType = rule.to;
         } else {
-            rule.affectedUnit = this.props.gameState.game.createUnit(rule.region, rule.to, this.props.gameState.house);
+            rule.affectedUnit = this.props.gameState.game.createUnit(rule.region, rule.to, this.house);
             rule.region.newUnits.push(rule.affectedUnit);
         }
 
         musterings.push(rule);
-        this.musterings.set(this.selectedRegion, musterings);
+        this.musterings.set(initiatingRegion, musterings);
 
-        if (this.props.gameState.getPointsLeft(this.selectedRegion, this.musterings) == 0) {
-            this.selectedRegion = null;
+        this.removeEmptyMusterings();
+
+        if (this.props.gameState.getPointsLeft(initiatingRegion, this.musterings) == 0) {
+            document.body.click();
         }
     }
 
     submit(): void {
-        if(this.props.gameState.anyUsablePointsLeft(this.musterings)) {
-            if(!confirm('You have not used all of your mustering points. Continue anyway?')){
+        if (this.props.gameState.anyUsablePointsLeft(this.musterings)) {
+            if (!confirm('You have not used all of your mustering points. Continue anyway?')){
                 return;
             }
         }
@@ -197,65 +208,90 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
         this.reset();
     }
 
-    private checkStarredConsolidatePower(region: Region): boolean {
-        if(this.props.gameState.type != PlayerMusteringType.STARRED_CONSOLIDATE_POWER) {
-            return true;
-        }
-
-        return this.props.gameState.hasStarredConsolidatePowerOrder(region);
-    }
-
     private getPowerTokenButtonText(): string {
-        const powerTokenCount = this.selectedRegion ? this.props.gameState.resolveConsolidatePowerGameState.getPotentialGainedPowerTokens(this.selectedRegion, this.house) : 0;
+        const powerTokenCount = this.musterings.size == 1 && this.musterings.values[0].length == 0 ? this.props.gameState.resolveConsolidatePowerGameState.getPotentialGainedPowerTokens(this.musterings.keys[0], this.house) : 0;
         return `Get ${powerTokenCount} Power token${powerTokenCount > 1 ? "s" : ""}`;
     }
 
-    modifyRegionsOnMap(): [Region, PartialRecursive<RegionOnMapProperties>][] {
-        if (this.props.gameClient.doesControlHouse(this.props.gameState.house)) {
-            if (this.props.gameState.type == PlayerMusteringType.MUSTERING_WESTEROS_CARD || this.props.gameState.type == PlayerMusteringType.THE_HORDE_DESCENDS_WILDLING_CARD) {
-                return this.props.gameState.game.world.regions.values
-                    .filter(r => r.getController() == this.props.gameState.house && this.props.gameState.getValidMusteringRulesForRegion(r, this.musterings).length > 0)
-                    .map(r => [
-                            r,
-                            {
-                                highlight: {active: true},
-                                onClick: () => this.onRegionClick(r)
-                            }]
-                        );
-            }
-        }
+    private modifyRegionsOnMap(): [Region, PartialRecursive<RegionOnMapProperties>][] {
+        if (this.doesControlCurrentHouse) {
+            let regionsToModify = (this.isStarredConsolidatePowerMusteringType
+                ? this.props.gameState.resolveConsolidatePowerGameState.actionGameState.getRegionsWithConsolidatePowerOrderOfHouse(this.house).map(([r, _order]) => r).filter(r => this.hasStarredConsolidatePowerOrder(r))
+                : this.props.gameState.game.world.regions.values.filter(r => r.getController() == this.house)).filter(r => this.props.gameState.getValidMusteringRulesForRegion(r, this.musterings).length > 0);
 
-        return [];
-    }
-
-    modifyOrdersOnMap(): [Region, PartialRecursive<OrderOnMapProperties>][] {
-        if (this.props.gameClient.doesControlHouse(this.props.gameState.house)) {
-            if (this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER) {
-                if (this.selectedRegion == null) {
-                    return this.props.gameState.game.world.getControlledRegions(this.props.gameState.house).filter(r => this.props.gameState.hasConsolidatePowerOrder(r))
-                    .map(r => [
-                        r,
-                        {
-                            highlight: {active: true},
-                            onClick: () => this.onOrderClick(r)
-                        }
-                    ]);
+            if (this.props.gameState.type == PlayerMusteringType.THE_HORDE_DESCENDS_WILDLING_CARD) {
+                if (this.musterings.size == 1) {
+                    regionsToModify = regionsToModify.filter(r => r == this.musterings.keys[0]);
                 }
             }
+
+            return regionsToModify
+                .map(modifiedRegion => [
+                        modifiedRegion,
+                        {
+                            highlight: {active: true},
+                            wrap: (!this.isStarredConsolidatePowerMusteringType || this.hasStarredConsolidatePowerOrder(modifiedRegion)) ? (child: ReactElement) => (
+                                <OverlayTrigger
+                                    placement="auto"
+                                    trigger="click"
+                                    rootClose
+                                    overlay={
+                                        <Popover id={"region-popover-" + modifiedRegion.id}>
+                                            <h5 style={{textAlign: "center"}}>{modifiedRegion.name} <small>({this.props.gameState.getUsedPointsForRegion(modifiedRegion, this.musterings)} / {modifiedRegion.castleLevel})</small></h5>
+                                            <>
+                                                {this.props.gameState.getValidMusteringRulesForRegion(modifiedRegion, this.musterings).length > 0 && (
+                                                    <>
+                                                        {this.props.gameState.getValidMusteringRules(modifiedRegion, this.musterings).map(({region, rules}) => (
+                                                            rules.map((rule, i) => (
+                                                                <Col key={modifiedRegion.id + "_muster-rule_" + i}>
+                                                                    <Button onClick={() => this.addMustering(modifiedRegion, rule)}>
+                                                                        {rule.from ? "Upgrade to " : "Recruit "} a {rule.to.name}{region != modifiedRegion && (" in " + region.name)} [{rule.cost}]
+                                                                    </Button>
+                                                                </Col>
+                                                            ))
+                                                        ))}
+                                                    </>
+                                                )}
+                                            </>
+                                        </Popover>
+                                    }
+                                >
+                                    {child}
+                                </OverlayTrigger>
+                            ) : null
+                        }]
+                    );
+            }
+
+        return [];
+    }
+
+    private modifyOrdersOnMap(): [Region, PartialRecursive<OrderOnMapProperties>][] {
+        if (this.doesControlCurrentHouse) {
+            if (this.isStarredConsolidatePowerMusteringType) {
+                return this.props.gameState.game.world.getControlledRegions(this.house).filter(r => this.hasConsolidatePowerOrder(r))
+                .map(r => [
+                    r,
+                    {
+                        highlight: {active: true},
+                        onClick: () => this.onOrderClick(r)
+                    }
+                ]);
+            }
         }
 
         return [];
     }
 
-    modifyUnitsOnMap(): [Unit, PartialRecursive<UnitOnMapProperties>][] {
-        if (this.props.gameClient.doesControlHouse(this.house)) {
+    private modifyUnitsOnMap(): [Unit, PartialRecursive<UnitOnMapProperties>][] {
+        if (this.doesControlCurrentHouse) {
             const allMusteredToRegions = _.uniq(_.flatMap(this.musterings.values).map(m => m.region));
             const allMusteredUnitsOfHouse = _.flatMap(allMusteredToRegions.map(r => _.concat(r.newUnits, r.units.values.filter(u => u.upgradedType != undefined))));
 
             return allMusteredUnitsOfHouse.map(u => [
                 u,
                 {
-                    highlight: { active: true, color: "yellow" },
+                    highlight: { active: true, color: u.upgradedType ? "yellow" : "green"},
                     onClick: () => {
                         this.onUnitClick(u);
                     }
@@ -275,35 +311,21 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
     componentWillUnmount(): void {
         _.pull(this.props.mapControls.modifyOrdersOnMap, this.modifyOrdersOnMapCallback);
         _.pull(this.props.mapControls.modifyRegionsOnMap, this.modifyRegionsOnMapCallback);
+        _.pull(this.props.mapControls.modifyUnitsOnMap, this.modifyUnitsOnMapCallback);
     }
 
-
-    private onRegionClick(region: Region): void {
-        if (region.getController() != this.props.gameState.house) {
+    private onOrderClick(region: Region): void {
+        if (region.getController() != this.house || !this.isStarredConsolidatePowerMusteringType) {
             return;
         }
 
-        if (this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER) {
-            this.selectedRegion = this.props.gameState.hasConsolidatePowerOrder(region) ? region : null;
-            if(this.selectedRegion) {
-                this.musterings.set(this.selectedRegion, []);
-            }
-        } else if(region.castleLevel > 0) {
-            this.selectedRegion = region;
-        }
+        this.reset();
+
+        this.musterings = new BetterMap();
+        this.musterings.set(region, []);
     }
 
-    private onOrderClick(r: Region): void {
-        if (this.props.gameState.type == PlayerMusteringType.STARRED_CONSOLIDATE_POWER) {
-            if (this.selectedRegion == null) {
-                if (this.props.gameClient.doesControlHouse(r.getController())) {
-                    this.onRegionClick(r);
-                }
-            }
-        }
-    }
-
-    onUnitClick(unit: Unit): void {
+    private onUnitClick(unit: Unit): void {
         for (const musteredRegion of this.musterings.keys) {
             const musterings = this.musterings.get(musteredRegion);
 
@@ -323,20 +345,17 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
             r.region.units.values.forEach(u => u.upgradedType = undefined);
         });
 
-        this.selectedRegion = null;
-        this.musterings = new BetterMap<Region, Mustering[]>();
+        this.musterings = new BetterMap();
     }
 
     submitForPT(): void {
-        if (this.selectedRegion == null) {
-            return;
-        }
-
         // Send a mustering with only one region, with no recruitements.
         // This acts as a consolidate power
-        this.props.gameState.muster(new BetterMap([
-            [this.selectedRegion, []]
-        ]));
+        if (this.musterings.size != 1 || this.musterings.values[0].length != 0) {
+            throw new Error("submitForPT was clicked but this.musterings contains unit recruitments");
+        }
+
+        this.props.gameState.muster(this.musterings);
 
         this.reset();
     }

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -275,6 +275,15 @@ $attacking-army-outline: rgba(red, 1.0);
   filter: drop-shadow(4px 4px 4px $attacking-army-outline) drop-shadow(-4px -4px 4px $attacking-army-outline);
 }
 
+$unit-highlight-outline-yellow: rgba(yellow, 1.0);
+.unit-highlight-yellow {
+  filter: drop-shadow(4px 4px 4px $unit-highlight-outline-yellow) drop-shadow(-4px -4px 4px $unit-highlight-outline-yellow);
+}
+
+.unit-highlight-yellow:hover {
+  filter: drop-shadow(4px 4px 4px $unit-highlight-outline-yellow) drop-shadow(-4px -4px 4px $unit-highlight-outline-yellow);
+}
+
 $wildling-outline: rgba(#f8ff00, 0.5);
 .wildling-highlight {
   filter: drop-shadow(1px 1px 3px $wildling-outline) drop-shadow(-1px -1px 3px $wildling-outline);

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -284,6 +284,15 @@ $unit-highlight-outline-yellow: rgba(yellow, 1.0);
   filter: drop-shadow(4px 4px 4px $unit-highlight-outline-yellow) drop-shadow(-4px -4px 4px $unit-highlight-outline-yellow);
 }
 
+$unit-highlight-outline-green: rgba(green, 1.0);
+.unit-highlight-green {
+  filter: drop-shadow(4px 4px 4px $unit-highlight-outline-green) drop-shadow(-4px -4px 4px $unit-highlight-outline-green);
+}
+
+.unit-highlight-green:hover {
+  filter: drop-shadow(4px 4px 4px $unit-highlight-outline-green) drop-shadow(-4px -4px 4px $unit-highlight-outline-green);
+}
+
 $wildling-outline: rgba(#f8ff00, 0.5);
 .wildling-highlight {
   filter: drop-shadow(1px 1px 3px $wildling-outline) drop-shadow(-1px -1px 3px $wildling-outline);

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Region.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Region.ts
@@ -8,6 +8,7 @@ import StaticRegion from "./static-data-structure/StaticRegion";
 import staticWorld from "./static-data-structure/globalStaticWorld";
 import Point from "../../../utils/Point";
 import UnitSlot from "../../../utils/unitSlot";
+import _ from "lodash";
 
 export default class Region {
     game: Game;
@@ -16,6 +17,10 @@ export default class Region {
     @observable units: BetterMap<number, Unit>;
     garrison: number;
     @observable controlPowerToken: House | null;
+
+    // Client-side only to support live update of planned musterings
+    @observable newUnits: Unit[];
+
 
     get staticRegion(): StaticRegion {
         return staticWorld.staticRegions.get(this.id);
@@ -63,6 +68,10 @@ export default class Region {
         return this.staticRegion.powerTokenSlot;
     }
 
+    get allUnits(): Unit[] {
+        return _.concat(this.units.values, this.newUnits);
+    }
+
     constructor(
         game: Game, id: string, garrison: number, controlPowerToken: House | null = null, units: BetterMap<number, Unit> = new BetterMap<number, Unit>()
     ) {
@@ -71,6 +80,7 @@ export default class Region {
         this.units = units;
         this.garrison = garrison;
         this.controlPowerToken = controlPowerToken;
+        this.newUnits = [];
     }
 
     getController(): House | null {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Unit.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Unit.ts
@@ -3,6 +3,7 @@ import House from "./House";
 import unitTypes from "./unitTypes";
 import Game from "./Game";
 import Region from "./Region";
+import { observable } from "mobx";
 
 export default class Unit {
     id: number;
@@ -10,6 +11,9 @@ export default class Unit {
     type: UnitType;
     wounded = false;
     allegiance: House;
+
+    // Client-side only to support live update of planned musterings
+    @observable upgradedType?: UnitType;
 
     constructor(id: number, type: UnitType, allegiance: House) {
         this.id = id;


### PR DESCRIPTION
Closes #653 

The mustered units now appear on the map and can be clicked to be removed again:

![image](https://user-images.githubusercontent.com/22304202/108722053-ff730d00-7522-11eb-8863-ecd0f08e5581.png)


@Longwelwind How did you plan to solve the issue? I right now added new properties client-side only to render the newly mustered units or is there a better solution? Can you check my review comments and if you in general agree with that idea I would create the popover then and merge.