### PR TITLE
Reset Bronn after usage and fix possible invalid call of doesControlHouse

### DIFF
--- a/agot-bg-game-server/src/client/GameClient.ts
+++ b/agot-bg-game-server/src/client/GameClient.ts
@@ -106,7 +106,13 @@ export default class GameClient {
         const player = this.authenticatedPlayer;
 
         if (player) {
-            return ingame.getControllerOfHouse(house) == player;
+            // Houses may be uncontrolled during Claim Vassals state and getControllerOfHouse will throw an error.
+            // We have to catch it here
+            try {
+                return ingame.getControllerOfHouse(house) == player;
+            } catch {
+                return false;
+            }
         } else {
             return false;
         }

--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -204,10 +204,10 @@ export default class IngameGameState extends GameState<
 
     getControllerOfHouse(house: House): Player {
         if (this.isVassalHouse(house)) {
-            const suzerainHouse = this.game.vassalRelations.get(house);
+            const suzerainHouse = this.game.vassalRelations.tryGet(house, null);
 
             if (suzerainHouse == null) {
-                throw new Error();
+                throw new Error(`getControllerOfHouse(${house.name}) failed as there is no suzerainHouse`);
             }
 
             return this.getControllerOfHouse(suzerainHouse);
@@ -215,7 +215,7 @@ export default class IngameGameState extends GameState<
             const player = this.players.values.find(p => p.house == house);
 
             if (player == null) {
-                throw new Error();
+                throw new Error(`getControllerOfHouse(${house.name}) failed due to a fatal error`);
             }
 
             return player;

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/ResolveMarchOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/ResolveMarchOrderGameState.ts
@@ -58,7 +58,7 @@ export default class ResolveMarchOrderGameState extends GameState<ActionGameStat
         this.findOrphanedOrdersAndRemoveThem();
 
         // Reset all card abilities (e.g. due to DWD Queen of Thorns)
-        const allHouseCards = _.flatMap(this.game.houses.values.map(h => h.houseCards.values));
+        const allHouseCards = _.concat(_.flatMap(this.game.houses.values.map(h => h.houseCards.values)), this.game.vassalHouseCards.values);
         const manipulatedHouseCards = allHouseCards.filter(hc =>
                hc.disabled
             || hc.combatStrength != hc.originalCombatStrength

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState.ts
@@ -39,7 +39,7 @@ export default class BronnAbilityGameState extends GameState<
                 type: "house-card-ability-not-used",
                 house: this.enemy.id,
                 houseCard: bronn.id
-            })
+            });
             this.parentGameState.onHouseCardResolutionFinish(house);
             return;
         }
@@ -59,7 +59,7 @@ export default class BronnAbilityGameState extends GameState<
                 type: "house-card-ability-not-used",
                 house: this.enemy.id,
                 houseCard: bronn.id
-            })
+            });
             this.parentGameState.onHouseCardResolutionFinish(house);
             return;
         }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -54,7 +54,7 @@ export default class Game {
      * Contains the vassal relations of the game.
      * Key is the vassal house, value is the commander.
      */
-    @observable vassalRelations = new BetterMap<House, House>();
+    vassalRelations = new BetterMap<House, House>();
     revealedWesterosCards = 0;
 
     get ironThroneHolder(): House {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/JaqenHGharHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/JaqenHGharHouseCardAbility.ts
@@ -6,8 +6,7 @@ import HouseCard, { HouseCardState } from "./HouseCard";
 import _ from "lodash";
 
 export default class JaqenHGharHouseCardAbility extends HouseCardAbility {
-
-    cancel(cancelResolutionState: CancelHouseCardAbilitiesGameState, house: House, houseCard: HouseCard): void {
+    cancel(cancelResolutionState: CancelHouseCardAbilitiesGameState, house: House, _houseCard: HouseCard): void {
         const combat = cancelResolutionState.combatGameState;
         const enemy = combat.getEnemy(house);
 
@@ -18,7 +17,7 @@ export default class JaqenHGharHouseCardAbility extends HouseCardAbility {
             type: "jaqen-h-ghar-house-card-replaced",
                 house: house.id,
                 affectedHouse: enemy.id,
-                oldHouseCard: houseCard.id,
+                oldHouseCard: (combat.houseCombatDatas.get(enemy).houseCard as HouseCard).id,
                 newHouseCard: newHouseCard.id
         });
 


### PR DESCRIPTION
… on client side after vassalRelations have been cleared. In some cases a client component is still loaded when the vassal relations are reset, e.g. when a battle directly leads to the ClaimVassals gamestate (No child game-state becomes active between combat and claim vassals, i.e. no retreat, no other house card state and no westeros state (2 last-days-of-summer and e.g. rains auf autumn). This led to a `map does not contain key [Object object]` error client-side as the still loaded component calls `doesControlHouse()` which itself used the now reset `vassalRelations`. This PR resets Bronn after combat and solves this map doesn't contain key issue. Jaqen H'Ghar also received some minor patches.