### PR TITLE
Allow bypassing canReady() again and fix Aeron DWD to not misuse BiddingGameState

### DIFF
--- a/agot-bg-game-server/src/client/CombatInfoComponent.tsx
+++ b/agot-bg-game-server/src/client/CombatInfoComponent.tsx
@@ -63,7 +63,7 @@ export default class CombatInfoComponent extends Component<CombatInfoComponentPr
                         {this.attacker.houseCard ? (
                             <HouseCardComponent houseCard={this.attacker.houseCard}
                                                 size="small" />
-                        ) : this.attacker.attackerHouseCardChosen 
+                        ) : this.attacker.attackerHouseCardChosen
                         ? <div
                                 className="vertical-game-card small"
                                 style={{
@@ -78,7 +78,7 @@ export default class CombatInfoComponent extends Component<CombatInfoComponentPr
                         {this.defender.houseCard ? (
                             <HouseCardComponent houseCard={this.defender.houseCard}
                                                 size="small" />
-                        ) : this.defender.defenderHouseCardChosen 
+                        ) : this.defender.defenderHouseCardChosen
                         ? <div
                                 className="vertical-game-card small"
                                 style={{

--- a/agot-bg-game-server/src/client/game-state-panel/PlaceOrdersComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlaceOrdersComponent.tsx
@@ -104,7 +104,7 @@ export default class PlaceOrdersComponent extends Component<GameStateComponentPr
     }
 
     showButtons(): boolean {
-        return !this.props.gameState.forVassals || this.props.gameState.ingameGameState.getVassalsControlledByPlayer(this.player).length > 0;
+        return !this.props.gameState.forVassals || this.props.gameState.ingame.getVassalsControlledByPlayer(this.player).length > 0;
     }
 
     isOrderAvailable(order: Order): boolean {

--- a/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PlayerMusteringComponent.tsx
@@ -68,7 +68,7 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                         <>Vassal house <b>{this.house.name}</b> can resolve their Muster Order{this.defenseMusterOrderRegion && <> in <b>{this.defenseMusterOrderRegion.name}</b></>}.</>
                     )}
                 </Col>
-                {this.doesControlCurrentHouse ? (
+                {this.doesControlCurrentHouse &&
                     <>
                         {this.musterings.size > 0 &&
                             <Col xs={12}>
@@ -124,12 +124,11 @@ export default class PlayerMusteringComponent extends Component<GameStateCompone
                                 </Col>
                             </Row>
                         </Col>
-                    </>
-                ) : (
-                    <Col xs={12} className="text-center">
-                        Waiting for {this.house.name}...
-                    </Col>
-                )}
+                    </>}
+                {(!this.doesControlCurrentHouse || this.props.gameState.ingame.isVassalHouse(this.house)) && 
+                <Col xs={12} className="text-center">
+                    Waiting for {this.house.name}...
+                </Col>}
             </>
         );
     }

--- a/agot-bg-game-server/src/client/game-state-panel/house-card-abilities/AeronDamphairDwDAbilityComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/house-card-abilities/AeronDamphairDwDAbilityComponent.tsx
@@ -1,24 +1,63 @@
 import {observer} from "mobx-react";
 import {Component, ReactNode} from "react";
 import GameStateComponentProps from "../GameStateComponentProps";
-import renderChildGameState from "../../utils/renderChildGameState";
 import React from "react";
 import Col from "react-bootstrap/Col";
 import AeronDamphairDwDAbilityGameState from "../../../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/aeron-damphair-dwd-ability-game-state/AeronDamphairDwDAbilityGameState";
-import BiddingGameState from "../../../common/ingame-game-state/westeros-game-state/bidding-game-state/BiddingGameState";
-import BiddingComponent from "../BiddingComponent";
+import Player from "../../../common/ingame-game-state/Player";
+import { Button, Row } from "react-bootstrap";
+import { observable } from "mobx";
 
 @observer
 export default class AeronDamphairAbilityComponent extends Component<GameStateComponentProps<AeronDamphairDwDAbilityGameState>> {
+    @observable powerTokens = 0;
+
+    get authenticatedPlayer(): Player | null {
+        return this.props.gameClient.authenticatedPlayer;
+    }
+
     render(): ReactNode {
         return (
             <>
                 <Col xs={12}>
                     <b>Aeron Damphair:</b> Greyjoy may discard any number of available Power token to increase the combat strength of his card by the number of Power tokens discarded.
                 </Col>
-                {renderChildGameState(this.props, [
-                    [BiddingGameState, BiddingComponent],
-                ])}
+                {this.authenticatedPlayer && this.props.gameClient.doesControlHouse(this.props.gameState.house) && (
+                    <>
+                        <Col xs={12}>
+                            <Row className="justify-content-center">
+                                <Col xs="auto">
+                                    <input
+                                        type="range"
+                                        className="custom-range"
+                                        min={0}
+                                        max={this.authenticatedPlayer.house.powerTokens}
+                                        value={this.powerTokens}
+                                        onChange={e => {
+                                            this.powerTokens = parseInt(e.target.value);
+                                        }}
+                                        disabled={this.authenticatedPlayer.house.powerTokens==0}
+                                    />
+                                </Col>
+                                <Col xs="auto">
+                                    <div style={{marginLeft: "10px"}}>
+                                        {this.powerTokens}
+                                    </div>
+                                </Col>
+                            </Row>
+                        </Col>
+                        <Col xs={12} className="text-center">
+                            <Button
+                                onClick={() => this.props.gameState.sendPowerTokens(this.powerTokens)}
+                            >
+                                Confirm
+                            </Button>
+                        </Col>
+                    </>
+                )}
+                <Col xs={12} className="text-center">
+                    Waiting for {this.props.gameState.house.name} ...
+                </Col>
             </>
         );
     }

--- a/agot-bg-game-server/src/common/GameState.ts
+++ b/agot-bg-game-server/src/common/GameState.ts
@@ -1,6 +1,7 @@
 import {observable} from "mobx";
 import EntireGame from "./EntireGame";
 import User from "../server/User";
+import House from "./ingame-game-state/game-data-structure/House";
 
 type AnyGameState = GameState<any, any> | null;
 
@@ -95,6 +96,9 @@ export default class GameState<ParentGameState extends AnyGameState, ChildGameSt
 
     deserializeChildGameState(_data: any): ChildGameState {
         throw new Error(`"deserializeChildGameState" is not defined for class "${this.constructor.name}"`);
+    }
+
+    actionAfterVassalReplacement(_newVassal: House): void {
     }
 }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/choose-house-card-game-state/ChooseHouseCardGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/choose-house-card-game-state/ChooseHouseCardGameState.ts
@@ -63,7 +63,7 @@ export default class ChooseHouseCardGameState extends GameState<CombatGameState>
             this.houseCards.set(house, message.houseCardId
                 ? this.combatGameState.game.getHouseCardById(message.houseCardId)
                 : null);
-            
+
             if (this.combatGameState.attacker == house) {
                 this.combatGameState.attackerHouseCardChosen = this.ingameGameState.isVassalHouse(house) ? "vassal" : house.id;
             } else {

--- a/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/place-orders-game-state/PlaceOrdersGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/place-orders-game-state/PlaceOrdersGameState.ts
@@ -102,14 +102,18 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
             });
         }
 
+        this.entireGame.broadcastToClients({
+            type: "player-ready",
+            userId: player.user.id
+        });
+
         // Check if all players are ready
+        this.checkAllPlayersReady();
+    }
+
+    private checkAllPlayersReady(): void {
         if (this.readyHouses.length == this.participatingHouses.length) {
             this.planningGameState.onPlaceOrderFinish(this.forVassals, this.placedOrders as BetterMap<Region, Order>);
-        } else {
-            this.entireGame.broadcastToClients({
-                type: "player-ready",
-                userId: player.user.id
-            });
         }
     }
 
@@ -379,6 +383,15 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
 
     isReady(house: House): boolean {
         return this.readyHouses.includes(house);
+    }
+
+    /*
+     Action after vassal replacement
+    */
+
+    actionAfterVassalReplacement(newVassal: House): void {
+        this.readyHouses = _.without(this.readyHouses, newVassal);
+        this.checkAllPlayersReady();
     }
 
     static deserializeFromServer(planning: PlanningGameState, data: SerializedPlaceOrdersGameState): PlaceOrdersGameState {

--- a/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/place-orders-game-state/PlaceOrdersGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/place-orders-game-state/PlaceOrdersGameState.ts
@@ -32,7 +32,7 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
      */
     @observable forVassals: boolean;
 
-    get ingameGameState(): IngameGameState {
+    get ingame(): IngameGameState {
         return this.parentGameState.parentGameState;
     }
 
@@ -41,7 +41,7 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
     }
 
     get game(): Game {
-        return this.ingameGameState.game;
+        return this.ingame.game;
     }
 
     get world(): World {
@@ -49,25 +49,33 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
     }
 
     get entireGame(): EntireGame {
-        return this.ingameGameState.entireGame;
+        return this.ingame.entireGame;
+    }
+
+    get participatingHouses(): House[] {
+        return this.forVassals ? this.game.houses.values.filter(h => this.ingame.isVassalHouse(h)) : this.game.houses.values.filter(h => !this.ingame.isVassalHouse(h));
     }
 
     firstStart(orders = new BetterMap<Region, Order>(), forVassals = false): void {
         this.placedOrders = orders;
         this.forVassals = forVassals;
 
-        if (!this.forVassals || this.ingameGameState.getVassalHouses().length > 0) {
-            this.ingameGameState.log({
+        if (!this.forVassals || this.ingame.getVassalHouses().length > 0) {
+            this.ingame.log({
                 type: "planning-phase-began",
                 forVassals: this.forVassals
             });
         }
 
         // Automatically set ready for houses which can't place orders
-        this.game.houses.values.forEach(h => {
-            // The easiest way is to simply call this.setReady() as it checks for canReady
-            // but this from now on disables the possibilty to bypass canReady :(
-            this.setReady(this.ingameGameState.getControllerOfHouse(h));
+        this.ingame.players.forEach(p => {
+            const availableRegionsForOrders = this.forVassals
+            ? this.ingame.getVassalsControlledByPlayer(p).reduce((count, h) => count + this.getPossibleRegionsForOrders(h).length, 0)
+            : this.getPossibleRegionsForOrders(p.house).length;
+
+            if (availableRegionsForOrders == 0) {
+                this.setReady(p);
+            }
         });
     }
 
@@ -76,18 +84,26 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
             return;
         }
 
-        this.readyHouses.push(player.house);
+        if (this.forVassals) {
+            this.readyHouses.push(...this.ingame.getVassalsControlledByPlayer(player));
+        } else {
+            this.readyHouses.push(player.house);
+        }
 
-        if (!this.forVassals || this.ingameGameState.getVassalsControlledByPlayer(player).length > 0) {
-            this.ingameGameState.log({
+        // This is for debug to allow bypassing canReady and a player sending "ready" more than once
+        // It doesn't hurt on the live system either...
+        this.readyHouses = _.uniq(this.readyHouses);
+
+        if (!this.forVassals || this.ingame.getVassalsControlledByPlayer(player).length > 0) {
+            this.ingame.log({
                 type: "player-action",
                 house: player.house.id,
                 action: PlayerActionType.ORDERS_PLACED
-            })
+            });
         }
 
         // Check if all players are ready
-        if (this.readyHouses.length == this.ingameGameState.players.size) {
+        if (this.readyHouses.length == this.participatingHouses.length) {
             this.planningGameState.onPlaceOrderFinish(this.forVassals, this.placedOrders as BetterMap<Region, Order>);
         } else {
             this.entireGame.broadcastToClients({
@@ -98,7 +114,8 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
     }
 
     canUnready(player: Player): {status: boolean; reason: string} {
-        if (!this.isReady(player)) {
+        if ((this.forVassals && this.ingame.getVassalsControlledByPlayer(player).some(h => !this.isReady(h)))
+            || (!this.forVassals && !this.isReady(player.house))) {
             return {status: false, reason: "not-ready"};
         }
 
@@ -110,7 +127,9 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
             return;
         }
 
-        this.readyHouses.splice(this.readyHouses.indexOf(player.house), 1);
+        this.readyHouses = this.forVassals
+                ? _.without(this.readyHouses, ...this.ingame.getVassalsControlledByPlayer(player))
+                : _.without(this.readyHouses, player.house);
 
         this.entireGame.broadcastToClients({
             type: "player-unready",
@@ -153,7 +172,7 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
                     region: region.id
                 });
 
-                this.ingameGameState.players.values.filter(p => p != player).forEach(p => {
+                this.ingame.players.values.filter(p => p != player).forEach(p => {
                     p.user.send({
                         type: "order-placed",
                         region: region.id,
@@ -181,14 +200,14 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
         const possibleRegions = this.game.world.getControlledRegions(house).filter(r => r.units.size > 0);
 
         if (!this.forVassals) {
-            if (!this.ingameGameState.isVassalHouse(house)) {
+            if (!this.ingame.isVassalHouse(house)) {
                 return possibleRegions;
             } else {
                 return [];
             }
         }
 
-        if (!this.ingameGameState.isVassalHouse(house)) {
+        if (!this.ingame.isVassalHouse(house)) {
             return [];
         }
 
@@ -206,7 +225,7 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
             // Hide orders that doesn't belong to the player
             // If admin, send all orders.
             const controller = r.getController();
-            if (admin || (player && controller != null && (controller == player.house || (this.ingameGameState.isVassalHouse(controller) && this.ingameGameState.isVassalControlledByPlayer(controller, player))))) {
+            if (admin || (player && controller != null && (controller == player.house || (this.ingame.isVassalHouse(controller) && this.ingame.isVassalControlledByPlayer(controller, player))))) {
                 return o ? o.id : null;
             }
             return null;
@@ -225,7 +244,12 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
      */
 
     canReady(player: Player): {status: boolean; reason: string} {
-        if (this.isReady(this.ingameGameState.getControllerOfHouse(player.house))) {
+        // Here we can bypass canReady for debugging
+        // return {status: true, reason: "bypassed"};
+
+        // Return false if player is already ready
+        if ((this.forVassals && this.ingame.getVassalsControlledByPlayer(player).every(h => this.isReady(h)))
+            || (!this.forVassals && this.isReady(player.house))) {
             return {status: false, reason: "already-ready"};
         }
 
@@ -261,7 +285,7 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
             return {status: false, reason: "not-all-regions-filled"};
         }, null);
 
-        return possibleError ? possibleError : {status: true, reason: ""};
+        return possibleError ? possibleError as {status: boolean; reason: string} : {status: true, reason: ""};
     }
 
     /**
@@ -300,13 +324,19 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
                 this.placedOrders.delete(region);
             }
         } else if (message.type == "player-ready") {
-            const player = this.ingameGameState.players.get(this.entireGame.users.get(message.userId));
+            const player = this.ingame.players.get(this.entireGame.users.get(message.userId));
 
-            this.readyHouses.push(player.house);
+            if (this.forVassals) {
+                this.readyHouses.push(...this.ingame.getVassalsControlledByPlayer(player));
+            } else {
+                this.readyHouses.push(player.house);
+            }
         } else if (message.type == "player-unready") {
-            const player = this.ingameGameState.players.get(this.entireGame.users.get(message.userId));
+            const player = this.ingame.players.get(this.entireGame.users.get(message.userId));
 
-            this.readyHouses.splice(this.readyHouses.indexOf(player.house), 1);
+            this.readyHouses = this.forVassals
+                ? _.without(this.readyHouses, ...this.ingame.getVassalsControlledByPlayer(player))
+                : _.without(this.readyHouses, player.house);
         }
     }
 
@@ -323,12 +353,12 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
         if (!this.forVassals) {
             return [player.house];
         } else {
-            return this.ingameGameState.getVassalsControlledByPlayer(player);
+            return this.ingame.getVassalsControlledByPlayer(player);
         }
     }
 
     getNotReadyPlayers(): Player[] {
-        return this.ingameGameState.players.values.filter(p => !this.readyHouses.includes(p.house));
+        return _.uniq(_.difference(this.participatingHouses, this.readyHouses).map(h => this.ingame.getControllerOfHouse(h)));
     }
 
     getWaitedUsers(): User[] {
@@ -336,19 +366,19 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
     }
 
     getOrdersList(house: House): Order[] {
-        return this.ingameGameState.game.getOrdersListForHouse(house);
+        return this.ingame.game.getOrdersListForHouse(house);
     }
 
     getAvailableOrders(house: House, region: Region | null = null): Order[] {
-        return this.ingameGameState.game.getAvailableOrders(this.placedOrders, house, region, this.parentGameState.planningRestrictions);
+        return this.ingame.game.getAvailableOrders(this.placedOrders, house, region, this.parentGameState.planningRestrictions);
     }
 
     isOrderRestricted(order: Order): boolean {
         return this.parentGameState.planningRestrictions.some(restriction => restriction.restriction(order.type));
     }
 
-    isReady(player: Player): boolean {
-        return this.readyHouses.includes(player.house);
+    isReady(house: House): boolean {
+        return this.readyHouses.includes(house);
     }
 
     static deserializeFromServer(planning: PlanningGameState, data: SerializedPlaceOrdersGameState): PlaceOrdersGameState {

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -5,6 +5,7 @@ import { CrowKillersStep } from "../common/ingame-game-state/westeros-game-state
 import { SerializedHouse } from "../common/ingame-game-state/game-data-structure/House";
 import { HouseCardState } from "../common/ingame-game-state/game-data-structure/house-card/HouseCard";
 import { vassalHouseCards } from "../common/ingame-game-state/game-data-structure/static-data-structure/vassalHouseCards";
+import _ from "lodash";
 
 const serializedGameMigrations: {version: string; migrate: (serializeGamed: any) => any}[] = [
     {
@@ -568,6 +569,26 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
             if (serializedGame.childGameState.type == "ingame") {
                 const ingame = serializedGame.childGameState;
                 ingame.game.vassalHouseCards = vassalHouseCards.map(hc => [hc.id, hc.serializeToClient()]);
+            }
+
+            return serializedGame;
+        }
+    },
+    {
+        version: "20",
+        migrate: (serializedGame: any) => {
+            // Migration for #TBD
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+                if (ingame.childGameState.type == "planning") {
+                    const planning = ingame.childGameState;
+                    if (planning.childGameState.type == "place-orders") {
+                        const placeOrders = planning.childGameState;
+                        const vassalHouses = new BetterMap(ingame.game.vassalRelations).keys as string[];
+                        const nonVassalHouses = _.difference(ingame.game.houses.map((sh: SerializedHouse) => sh.id), vassalHouses);
+                        placeOrders.readyHouses = placeOrders.readyHouses.filter((h: string) => placeOrders.forVassals ? vassalHouses.includes(h) : nonVassalHouses.includes(h));
+                    }
+                }
             }
 
             return serializedGame;

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -589,6 +589,22 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
                         placeOrders.readyHouses = placeOrders.readyHouses.filter((h: string) => placeOrders.forVassals ? vassalHouses.includes(h) : nonVassalHouses.includes(h));
                     }
                 }
+
+                if (ingame.childGameState.type == "action"
+                    && ingame.childGameState.childGameState.type == "resolve-march-order"
+                    && ingame.childGameState.childGameState.childGameState.type == "combat"
+                    && ingame.childGameState.childGameState.childGameState.childGameState.type == "before-combat-house-card-abilities-resolution"
+                    && ingame.childGameState.childGameState.childGameState.childGameState.childGameState.type == "house-card-resolution") {
+                        const houseCardResolution = ingame.childGameState.childGameState.childGameState.childGameState.childGameState;
+                        if (houseCardResolution.childGameState.type == "aeron-damphair-dwd-ability") {
+                            const oldAeronState = houseCardResolution.childGameState;
+
+                            houseCardResolution.childGameState = {
+                                type: "aeron-damphair-dwd-ability",
+                                house: oldAeronState.childGameState.participatingHouses[0]
+                            }
+                        }
+                }
             }
 
             return serializedGame;


### PR DESCRIPTION
Fixes as well replacing a player by vassal during `PlaceOrdersGameState`

Closes #873 
Closes #855 
Closes #857 
