### PR TITLE
Send PBEM notification only to offline users

### DIFF
--- a/agot-bg-game-server/src/server/GlobalServer.ts
+++ b/agot-bg-game-server/src/server/GlobalServer.ts
@@ -266,7 +266,7 @@ export default class GlobalServer {
     }
 
     onWaitedUsers(game: EntireGame, users: User[]): void {
-        this.websiteClient.notifyUsers(game.id, users.map(u => u.id));
+        this.websiteClient.notifyUsers(game.id, users.filter(u => !u.connected).map(u => u.id));
     }
 
     onClose(client: WebSocket): void {


### PR DESCRIPTION
I just received 3 subsequent emails in a PBEM game where I already performed my action directly. This led me think about how to fix #138 and therefore we at least filter for offline users now.