### PR TITLE
VSB cannot be used when a house card overwrites final combat strength

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/HouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/HouseCardAbility.ts
@@ -68,7 +68,7 @@ export default class HouseCardAbility {
         return false;
     }
 
-    doesPreventCasualties(_combat: CombatGameState, _house: House, _houseCard: HouseCard, _affectedHouse: House): boolean {
+    doesPreventCasualties(_combat: CombatGameState, _house: House, _houseCard: HouseCard, _affectedHouseCard: HouseCard): boolean {
         return false;
     }
 
@@ -78,6 +78,10 @@ export default class HouseCardAbility {
 
     finalCombatStrength(_combat: CombatGameState, _house: House, _houseCard: HouseCard, _affectedHouseCard: HouseCard, strength: number): number {
         return strength;
+    }
+
+    overwritesFinalCombatStrength(_combat: CombatGameState, _house: House, _houseCard: HouseCard, _affectedHouseCard: HouseCard): boolean {
+        return false;
     }
 
     forcesValyrianSteelBladeDecision(_combat: CombatGameState, _valyrianSteelBladeHolder: House): boolean {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/MargaeryTyrellDwDAbilityHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/MargaeryTyrellDwDAbilityHouseCardAbility.ts
@@ -4,18 +4,21 @@ import House from "../House";
 import CombatGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export default class MargaeryTyrellDwDAbilityHouseCardAbility extends HouseCardAbility {
+    private getAffectedHouse(house: House, combat: CombatGameState, houseCard: HouseCard, affectedHouseCard: HouseCard): House {
+        return houseCard == affectedHouseCard ? house : combat.getEnemy(house);
+    }
+
+    overwritesFinalCombatStrength(combat: CombatGameState, house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): boolean {
+        const affectedHouse = this.getAffectedHouse(house, combat, houseCard, affectedHouseCard);
+
+        if (affectedHouse == combat.defender && (combat.defendingRegion.controlPowerToken == affectedHouse || combat.defendingRegion.superControlPowerToken == affectedHouse)) {
+            return houseCard != affectedHouseCard;
+        }
+
+        return false;
+    }
+
     finalCombatStrength(combat: CombatGameState, house: House, houseCard: HouseCard, affectedHouseCard: HouseCard, strength: number): number {
-        let defender: House;
-        if (houseCard == affectedHouseCard) {
-            defender = house;
-        } else {
-            defender = combat.getEnemy(house);
-        }
-
-        if (defender == combat.defender && (combat.defendingRegion.controlPowerToken == defender || combat.defendingRegion.superControlPowerToken == defender)) {
-            return houseCard != affectedHouseCard ? 2 : strength
-        }
-
-        return strength;
+        return this.overwritesFinalCombatStrength(combat, house, houseCard, affectedHouseCard) ? 2 : strength;
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/RayderHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/RayderHouseCardAbility.ts
@@ -4,7 +4,11 @@ import House from "../House";
 import CombatGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export default class RayderHouseCardAbility extends HouseCardAbility {
-    finalCombatStrength(combat: CombatGameState, house: House, houseCard: HouseCard, affectedHouseCard: HouseCard, strength: number): number {
-        return houseCard == affectedHouseCard ? combat.game.wildlingStrength: strength;
+    overwritesFinalCombatStrength(_combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): boolean {
+        return houseCard == affectedHouseCard;
+    }
+
+    finalCombatStrength(combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard, strength: number): number {
+        return this.overwritesFinalCombatStrength(combat, _house, houseCard, affectedHouseCard) ? combat.game.wildlingStrength: strength;
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/TheBlackfishHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/TheBlackfishHouseCardAbility.ts
@@ -4,8 +4,7 @@ import House from "../House";
 import HouseCard from "./HouseCard";
 
 export default class TheBlackfishHouseCardAbility extends HouseCardAbility {
-
-    doesPreventCasualties(_combat: CombatGameState, _house: House, _houseCard: HouseCard): boolean {
-        return true;
+    doesPreventCasualties(_combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): boolean {
+        return houseCard == affectedHouseCard;
     }
 }


### PR DESCRIPTION
Fix #929 


@Longwelwind @mmasztalerczuk 
As the final combat strength includes the possible VSB bonus we have to skip the VSB question in case a house card overwrites final combat strength. I don't have the time to test it right now, but maybe you wanna throw your thoughts in.