### PR TITLE
Introduce HouseCardModifier

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState.ts
@@ -9,6 +9,7 @@ import {ServerMessage} from "../../../../../../../messages/ServerMessage";
 import IngameGameState from "../../../../../IngameGameState";
 import BeforeCombatHouseCardAbilitiesGameState from "../BeforeCombatHouseCardAbilitiesGameState";
 import { bronn } from "../../../../../../../common/ingame-game-state/game-data-structure/house-card/houseCardAbilities";
+import HouseCardModifier from "../../../../../game-data-structure/house-card/HouseCardModifier";
 
 export default class BronnAbilityGameState extends GameState<
     BeforeCombatHouseCardAbilitiesGameState["childGameState"], SimpleChoiceGameState
@@ -73,11 +74,15 @@ export default class BronnAbilityGameState extends GameState<
             throw new Error();
         }
 
-        bronnHouseCard.combatStrength = 0;
+        const houseCardModifier = new HouseCardModifier();
+        houseCardModifier.combatStrength = -bronnHouseCard.combatStrength;
+
+        this.combatGameState.houseCardModifiers.set(bronn.id, houseCardModifier);
 
         this.entireGame.broadcastToClients({
-            type: "manipulate-combat-house-card",
-            manipulatedHouseCards: [bronnHouseCard].map(hc => [hc.id, hc.serializeToClient()])
+            type: "update-house-card-modifier",
+            id: bronn.id,
+            modifier: houseCardModifier
         });
 
         this.ingame.changePowerTokens(this.controllerOfEnemy, -2);

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/AeronDamphairDwDHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/AeronDamphairDwDHouseCardAbility.ts
@@ -3,10 +3,15 @@ import HouseCard from "./HouseCard";
 import House from "../House";
 import BeforeCombatHouseCardAbilitiesGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/BeforeCombatHouseCardAbilitiesGameState";
 import AeronDamphairDwDAbilityGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/aeron-damphair-dwd-ability-game-state/AeronDamphairDwDAbilityGameState";
+import CombatGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export default class AeronDamphairDwDHouseCardAbility extends HouseCardAbility {
     beforeCombatResolution(beforeCombat: BeforeCombatHouseCardAbilitiesGameState, house: House, _houseCard: HouseCard): void {
-        beforeCombat.childGameState.setChildGameState(new AeronDamphairDwDAbilityGameState(beforeCombat.childGameState))
-            .firstStart(house);
+        beforeCombat.childGameState.setChildGameState(new AeronDamphairDwDAbilityGameState(beforeCombat.childGameState)).firstStart(house);
+    }
+
+    modifyCombatStrength(combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): number {
+        const houseCardModifier = combat.houseCardModifiers.tryGet(this.id, null);
+        return houseCardModifier && houseCard == affectedHouseCard ? houseCardModifier.combatStrength : 0;
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/BronnHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/BronnHouseCardAbility.ts
@@ -3,10 +3,15 @@ import HouseCard from "./HouseCard";
 import House from "../House";
 import BeforeCombatHouseCardAbilitiesGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/BeforeCombatHouseCardAbilitiesGameState";
 import BronnAbilityGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState";
+import CombatGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export default class BronnHouseCardAbility extends HouseCardAbility {
     beforeCombatResolution(beforeCombat: BeforeCombatHouseCardAbilitiesGameState, house: House, _houseCard: HouseCard): void {
-        beforeCombat.childGameState.setChildGameState(new BronnAbilityGameState(beforeCombat.childGameState))
-            .firstStart(house);
+        beforeCombat.childGameState.setChildGameState(new BronnAbilityGameState(beforeCombat.childGameState)).firstStart(house);
+    }
+
+    modifyCombatStrength(combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): number {
+        const houseCardModifier = combat.houseCardModifiers.tryGet(this.id, null);
+        return houseCardModifier && houseCard == affectedHouseCard ? houseCardModifier.combatStrength : 0;
     }
 }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/HouseCardModifier.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/HouseCardModifier.ts
@@ -1,0 +1,5 @@
+export default class HouseCardModifier {
+    combatStrength = 0;
+    swordIcons = 0;
+    towerIcons = 0;
+}

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/QyburnAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/QyburnAbility.ts
@@ -4,10 +4,25 @@ import House from "../House";
 import QyburnAbilityGameState
     from "../../action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/qyburn-ability-game-state/QyburnAbilityGameState";
 import BeforeCombatHouseCardAbilitiesGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/BeforeCombatHouseCardAbilitiesGameState";
+import CombatGameState from "../../action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export default class QyburnHouseCardAbility extends HouseCardAbility {
     beforeCombatResolution(beforeCombat: BeforeCombatHouseCardAbilitiesGameState, house: House, _houseCard: HouseCard): void {
-        beforeCombat.childGameState.setChildGameState(new QyburnAbilityGameState(beforeCombat.childGameState))
-            .firstStart(house);
+        beforeCombat.childGameState.setChildGameState(new QyburnAbilityGameState(beforeCombat.childGameState)).firstStart(house);
+    }
+
+    modifyCombatStrength(combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): number {
+        const houseCardModifier = combat.houseCardModifiers.tryGet(this.id, null);
+        return houseCardModifier && houseCard == affectedHouseCard ? houseCardModifier.combatStrength : 0;
+    }
+
+    modifySwordIcons(combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): number {
+        const houseCardModifier = combat.houseCardModifiers.tryGet(this.id, null);
+        return houseCardModifier && houseCard == affectedHouseCard ? houseCardModifier.swordIcons : 0;
+    }
+
+    modifyTowerIcons(combat: CombatGameState, _house: House, houseCard: HouseCard, affectedHouseCard: HouseCard): number {
+        const houseCardModifier = combat.houseCardModifiers.tryGet(this.id, null);
+        return houseCardModifier && houseCard == affectedHouseCard ? houseCardModifier.towerIcons : 0;
     }
 }

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -8,6 +8,7 @@ import {UserSettings} from "./ClientMessage";
 import { SerializedWesterosCard } from "../common/ingame-game-state/game-data-structure/westeros-card/WesterosCard";
 import { SerializedVote } from "../common/ingame-game-state/vote-system/Vote";
 import { CrowKillersStep } from "../common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState";
+import HouseCardModifier from "../common/ingame-game-state/game-data-structure/house-card/HouseCardModifier";
 
 export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | OrderPlaced | PlayerReady | PlayerUnready
     | HouseCardChosen | CombatImmediatelyKilledUnits | SupportDeclared | SupportRefused | NewTurn | RemovePlacedOrder
@@ -20,7 +21,7 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | SettingsChanged | ChangeValyrianSteelBladeUse |  NewPrivateChatRoom | GameSettingsChanged
     | UpdateWesterosDecks | UpdateConnectionStatus | VoteStarted | VoteCancelled | VoteDone | PlayerReplaced
     | CrowKillersStepChanged | ManipulateCombatHouseCard
-    | VassalRelations;
+    | VassalRelations | UpdateHouseCardModifier;
 
 interface AuthenticationResponse {
     type: "authenticate-response";
@@ -304,4 +305,10 @@ interface CrowKillersStepChanged {
 interface VassalRelations {
     type: "vassal-relations";
     vassalRelations: [string, string][];
+}
+
+interface UpdateHouseCardModifier {
+    type: "update-house-card-modifier";
+    id: string;
+    modifier: HouseCardModifier;
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -687,6 +687,23 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "24",
+        migrate: (serializedGame: any) => {
+            // Migration for #952
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+
+                if (ingame.childGameState.type == "action"
+                    && ingame.childGameState.childGameState.type == "resolve-march-order"
+                    && ingame.childGameState.childGameState.childGameState.type == "combat") {
+                        ingame.childGameState.childGameState.childGameState.houseCardModifiers = [];
+                }
+            }
+
+            return serializedGame;
+        }
     }
 ];
 


### PR DESCRIPTION
Fix #871 
Closes #853

@Longwelwind 
I tried to fix the issue of modifying the printed combat strength of a house card to allow Balon to work properly against such cards. The problem is when I modify the "printed" combat strength by doing `houseCard.combatStrength = newValue` Balon will reset that new value though Qyburn for example is a counter card for Balon as the printed combat strength is 0. What do you think about the implementation in general?

I have one problem. Though I introduced a new ServerMessage `update-house-card-ability-game-state` the UI doesn't show the new value in case of VSB question: (I used Aeron to increase my strength by 2 to have a 4)

![image](https://user-images.githubusercontent.com/22304202/118694561-7a8b4d00-b80c-11eb-86cd-d7efa88df019.png)

It's even worth. Even after reload the value isn't shown so my `rerender++` hack I used for similar problems won't work here...

Do you have any idea what I am missing? Thank you in advance...