### PR TITLE
On client-side wait 3 seconds after combat is over to show the combat result to clients not only in GameLog

### DIFF
--- a/agot-bg-game-server/src/client/CombatInfoComponent.tsx
+++ b/agot-bg-game-server/src/client/CombatInfoComponent.tsx
@@ -46,7 +46,7 @@ export default class CombatInfoComponent extends Component<CombatInfoComponentPr
 
     render(): ReactNode {
         const showVsb = this.attacker.valyrianSteelBlade > 0 || this.defender.valyrianSteelBlade > 0;
-        const showTob = this.attacker.tidesOfBattleCard != undefined || this.defender.tidesOfBattleCard != undefined;
+        const showTob = this.attacker.tidesOfBattleCard !== undefined || this.defender.tidesOfBattleCard !== undefined;
         return (
             <>
                 <div style={{display: "grid", gridGap: "5px", gridTemplateColumns: "auto 1fr auto 1fr auto", justifyItems: "center", alignItems: "center"}} className="text-center">

--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -221,7 +221,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                 const houseCombatDatas = data.stats.map(stat => {
                     const house = this.game.houses.get(stat.house);
                     const houseCard = stat.houseCard != null ? this.allHouseCards.get(stat.houseCard) : null;
-                    const tidesOfBattleCard = stat.tidesOfBattleCard == undefined ? undefined : stat.tidesOfBattleCard != null ? tidesOfBattleCards.get(stat.tidesOfBattleCard) : null;
+                    const tidesOfBattleCard = stat.tidesOfBattleCard === undefined ? undefined : stat.tidesOfBattleCard != null ? tidesOfBattleCards.get(stat.tidesOfBattleCard) : null;
 
                     return {
                         ...stat,

--- a/agot-bg-game-server/src/client/game-state-panel/ChooseHouseCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ChooseHouseCardComponent.tsx
@@ -61,6 +61,7 @@ export default class ChooseHouseCardComponent extends Component<GameStateCompone
 
     render(): JSX.Element {
         return (
+            this.combat.stats.length > 0 ? <></> :
             <>
                 <Col xs={12}>
                     The attacker and the defender must choose a House Card

--- a/agot-bg-game-server/src/client/game-state-panel/PostCombatComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/PostCombatComponent.tsx
@@ -6,8 +6,7 @@ import ChooseCasualtiesGameState
 import ChooseCasualtiesComponent from "./ChooseCasualtiesComponent";
 import GameStateComponentProps from "./GameStateComponentProps";
 import renderChildGameState from "../utils/renderChildGameState";
-import PostCombatGameState
-, { CombatStats }    from "../../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState";
+import PostCombatGameState from "../../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState";
 import AfterWinnerDeterminationComponent from "./house-card-abilities/AfterWinnerDeterminationComponent";
 import AfterWinnerDeterminationGameState
     from "../../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/AfterWinnerDeterminationGameState";
@@ -17,11 +16,6 @@ import AfterCombatHouseCardAbilitiesComponent from "./house-card-abilities/After
 import ResolveRetreatGameState
     from "../../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/resolve-retreat-game-state/ResolveRetreatGameState";
 import ResolveRetreatComponent from "./ResolveRetreatComponent";
-import Col from "react-bootstrap/Col";
-import CombatInfoComponent from "../CombatInfoComponent";
-import HouseCard from "../../common/ingame-game-state/game-data-structure/house-card/HouseCard";
-import unitTypes from "../../common/ingame-game-state/game-data-structure/unitTypes";
-import { tidesOfBattleCards } from "../../common/ingame-game-state/game-data-structure/static-data-structure/tidesOfBattleCards";
 
 @observer
 export default class PostCombatComponent extends Component<GameStateComponentProps<PostCombatGameState>> {
@@ -29,37 +23,9 @@ export default class PostCombatComponent extends Component<GameStateComponentPro
         return this.props.gameState;
     }
 
-    get combatStats(): CombatStats[] {
-        return this.props.gameState.combatStats;
-    }
-
     render(): ReactNode {
-        const houseCombatDatas = this.combatStats.map(stat => {
-            const house = this.postCombat.game.houses.get(stat.house);
-            const houseCard = stat.houseCard ? this.getHouseCard(stat.houseCard) : null;
-            const tidesOfBattleCard = stat.tidesOfBattleCard == undefined ? undefined : stat.tidesOfBattleCard != null ? tidesOfBattleCards.get(stat.tidesOfBattleCard) : null;
-
-            return {
-                ...stat,
-                house,
-                region: this.postCombat.world.regions.get(stat.region),
-                houseCard: houseCard,
-                armyUnits: stat.armyUnits.map(ut => unitTypes.get(ut)),
-                tidesOfBattleCard: tidesOfBattleCard,
-                isWinner: house == this.postCombat.winner
-            };
-        });
         return (
             <>
-                {houseCombatDatas.length > 0 && <Col xs={12}>
-                    <div style={{ display: 'flex', justifyContent: 'center' }}>
-                        <h5>Battle for <b>{houseCombatDatas[1].region.name}</b></h5>
-                    </div>
-                    <CombatInfoComponent housesCombatData={houseCombatDatas}/>
-                </Col>}
-                <Col xs={12} className="text-center">
-                    Winner: {this.postCombat.winner.name}
-                </Col>
                 {renderChildGameState(this.props, [
                     [ChooseCasualtiesGameState, ChooseCasualtiesComponent],
                     [ResolveRetreatGameState, ResolveRetreatComponent],
@@ -68,14 +34,5 @@ export default class PostCombatComponent extends Component<GameStateComponentPro
                 ])}
             </>
         );
-    }
-
-    getHouseCard(id: string): HouseCard | null {
-        const filtered = this.postCombat.combat.houseCombatDatas.values.filter(hcd => hcd.houseCard && hcd.houseCard.id == id);
-        if (filtered.length == 1) {
-            return filtered[0].houseCard;
-        }
-
-        return null;
     }
 }

--- a/agot-bg-game-server/src/client/game-state-panel/UseValyrianSteelBladeComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/UseValyrianSteelBladeComponent.tsx
@@ -19,6 +19,7 @@ export default class UseValyrianSteelBladeComponent extends Component<GameStateC
     }
     render(): ReactNode {
         return (
+            this.gameState.combatGameState.stats.length > 0 ? <></> :
             <>
                 <Col xs={12}>
                     {this.gameState.ingame.getControllerOfHouse(this.house).house.name} may choose to use the

--- a/agot-bg-game-server/src/client/game-state-panel/house-card-abilities/PatchfaceAbilityComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/house-card-abilities/PatchfaceAbilityComponent.tsx
@@ -18,8 +18,8 @@ export default class PatchfaceAbilityComponent extends Component<GameStateCompon
         return (
             <>
                 <Col xs={12}>
-                    <b>Patchface</b>: House <b>{this.props.gameState.childGameState.house.name}</b> must choose one house card of
-                    house <b>{this.props.gameState.combat.getEnemy(this.props.gameState.childGameState.house).name}</b> to discard.
+                    <b>Patchface</b>: House <b>{this.props.gameState.childGameState.house.name}</b> may choose to discard one house card of
+                    house <b>{this.props.gameState.combat.getEnemy(this.props.gameState.childGameState.house).name}</b>.
                 </Col>
                 {renderChildGameState(this.props, [
                     [SimpleChoiceGameState, SimpleChoiceComponent],

--- a/agot-bg-game-server/src/common/GameState.ts
+++ b/agot-bg-game-server/src/common/GameState.ts
@@ -50,6 +50,14 @@ export default class GameState<ParentGameState extends AnyGameState, ChildGameSt
                 : false;
     }
 
+    hasParentGameState(gameState: any): boolean {
+        return this instanceof gameState
+            ? true
+            : this.parentGameState
+                ? this.parentGameState.hasParentGameState(gameState)
+                : false;
+    }
+
     getFirstChildGameState(gameState: any): AnyGameState | null {
         return this instanceof gameState
             ? this

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLog.ts
@@ -1,4 +1,4 @@
-import { CombatStats } from "../action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState";
+import { CombatStats } from "../action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export default interface GameLog {
     time: Date;

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/DaenerysTargaryenBHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/DaenerysTargaryenBHouseCardAbility.ts
@@ -7,8 +7,8 @@ import CombatGameState from "../../action-game-state/resolve-march-order-game-st
 export default class DaenerysTargaryenBHouseCardAbility extends HouseCardAbility {
     afterCombat(afterCombat: AfterCombatHouseCardAbilitiesGameState, house: House, _houseCard: HouseCard): void {
         const enemy = afterCombat.combatGameState.getEnemy(house);
-        const totalDifference = Math.abs(afterCombat.postCombatGameState.combatStats[0].total -
-            afterCombat.postCombatGameState.combatStats[1].total);
+        const totalDifference = Math.abs(afterCombat.combatGameState.stats[0].total -
+            afterCombat.combatGameState.stats[1].total);
 
         const powerTokensDiscarded = afterCombat.combatGameState.ingameGameState.changePowerTokens(enemy, -totalDifference);
 

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/IllyrioMopatisHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/IllyrioMopatisHouseCardAbility.ts
@@ -6,8 +6,8 @@ import CombatGameState from "../../action-game-state/resolve-march-order-game-st
 
 export default class IllyrioMopatisHouseCardAbility extends HouseCardAbility {
     afterCombat(afterCombat: AfterCombatHouseCardAbilitiesGameState, house: House, houseCard: HouseCard): void {
-        const totalDifference = Math.abs(afterCombat.postCombatGameState.combatStats[0].total -
-            afterCombat.postCombatGameState.combatStats[1].total);
+        const totalDifference = Math.abs(afterCombat.combatGameState.stats[0].total -
+            afterCombat.combatGameState.stats[1].total);
 
         const powerTokensGained = afterCombat.combatGameState.ingameGameState.changePowerTokens(house, totalDifference);
 

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/bidding-game-state/BiddingGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/bidding-game-state/BiddingGameState.ts
@@ -33,11 +33,13 @@ export default class BiddingGameState<ParentGameState extends BiddingGameStatePa
 
     onPlayerMessage(player: Player, message: ClientMessage): void {
         if (message.type == "bid") {
-            if (!this.participatingHouses.includes(player.house)) {
+            const bid = message.powerTokens;
+            if (!this.participatingHouses.includes(player.house)
+                || bid < 0
+                || bid > player.house.powerTokens) {
                 return;
             }
 
-            const bid = Math.max(0, Math.min(message.powerTokens, player.house.powerTokens));
             this.bids.set(player.house, bid);
 
             this.entireGame.sendMessageToClients(_.without(this.entireGame.users.values, player.user), {

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -9,6 +9,7 @@ import { SerializedWesterosCard } from "../common/ingame-game-state/game-data-st
 import { SerializedVote } from "../common/ingame-game-state/vote-system/Vote";
 import { CrowKillersStep } from "../common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/crow-killers-wildling-victory-game-state/CrowKillersWildlingVictoryGameState";
 import HouseCardModifier from "../common/ingame-game-state/game-data-structure/house-card/HouseCardModifier";
+import { CombatStats } from "../common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState";
 
 export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | OrderPlaced | PlayerReady | PlayerUnready
     | HouseCardChosen | CombatImmediatelyKilledUnits | SupportDeclared | SupportRefused | NewTurn | RemovePlacedOrder
@@ -21,7 +22,7 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | SettingsChanged | ChangeValyrianSteelBladeUse |  NewPrivateChatRoom | GameSettingsChanged
     | UpdateWesterosDecks | UpdateConnectionStatus | VoteStarted | VoteCancelled | VoteDone | PlayerReplaced
     | CrowKillersStepChanged | ManipulateCombatHouseCard | ChangeCombatTidesOfBattleCard
-    | VassalRelations | UpdateHouseCardModifier | UpdateHouseCards | UpdateHouseCardsForDrafting;
+    | VassalRelations | UpdateHouseCardModifier | UpdateHouseCards | UpdateHouseCardsForDrafting | UpdateCombatStats;
 
 interface AuthenticationResponse {
     type: "authenticate-response";
@@ -90,7 +91,7 @@ interface ChangeCombatHouseCard {
 
 interface ChangeCombatTidesOfBattleCard {
     type: "change-combat-tides-of-battle-card";
-    tidesOfBattleCardIds: [string, string][];
+    tidesOfBattleCardIds: [string, string | null][];
 }
 
 interface ManipulateCombatHouseCard {
@@ -327,4 +328,9 @@ interface UpdateHouseCards {
 interface UpdateHouseCardsForDrafting {
     type: "update-house-cards-for-drafting";
     houseCards: string[];
+}
+
+interface UpdateCombatStats {
+    type: "update-combat-stats";
+    stats: CombatStats[];
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -805,6 +805,28 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
             }
             return serializedGame;
         }
+    },
+    {
+        version: "31",
+        migrate: (serializedGame: any) => {
+            // Migration for Wait 3s after combat is finished
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+
+                if (ingame.childGameState.type == "action" &&
+                    ingame.childGameState.childGameState.type == "resolve-march-order" &&
+                    ingame.childGameState.childGameState.childGameState.type == "combat") {
+                    const combat = ingame.childGameState.childGameState.childGameState;
+
+                    if (combat.childGameState.type == "post-combat") {
+                        const postCombat = ingame.childGameState.childGameState.childGameState.childGameState;
+                        combat.stats = postCombat.combatStats;
+                    }
+                }
+            }
+
+            return serializedGame;
+        }
     }
 ];
 

--- a/agot-bg-game-server/src/utils/sleep.ts
+++ b/agot-bg-game-server/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export default function sleep(delay: number): Promise<void> {
+    return new Promise( res => setTimeout(res, delay) );
+}


### PR DESCRIPTION
The goal of this PR is to slow down the game a bit and allow seeing the drawn ToB card not only in GameLog if it doesn't come to PostCombat.

The remaining problem here is, that VSB usage is a `CombatGameState` child and the `CombatComponent` shows the `CombatInfoComponent` in a dynamic way. So if after VSB usage no PostCombat is triggered, but any house suffered casualties, the dialog will be updated and the army is recalculated which results in invalid values. Right now I have no idea how to solve it but I guess I'll find a solution in time.