### PR TITLE
A commander cannot use Bronn's ability in behalf of a vassal

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/before-combat-house-card-abilities-game-state/bronn-ability-game-state/BronnAbilityGameState.ts
@@ -35,7 +35,10 @@ export default class BronnAbilityGameState extends GameState<
     firstStart(house: House): void {
         this.enemy = this.combatGameState.getEnemy(house);
 
-        if (this.controllerOfEnemy.powerTokens < 2) {
+        // According to Jason Waldons answer the commander cannot use Bronn's ability:
+        // "Since vassals do not possess and thus cannot spend power tokens (page 7 of the Mother of Dragons rulebook),
+        // Bronn's effect cannot be resolved on behalf of a vassal."
+        if (this.ingame.isVassalHouse(this.enemy) || this.controllerOfEnemy.powerTokens < 2) {
             this.combatGameState.ingameGameState.log({
                 type: "house-card-ability-not-used",
                 house: this.enemy.id,

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-raid-order-game-state/resolve-single-raid-order-game-state/ResolveSingleRaidOrderGameState.ts
@@ -105,7 +105,7 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
             let raidedHouseLostPowerToken: boolean | null = null;
 
             if (orderTarget.type instanceof ConsolidatePowerOrderType && !(orderTarget.type instanceof IronBankOrderType)) {
-                raiderGainedPowerToken = this.ingameGameState.changePowerTokens(this.ingameGameState.getControllerOfHouse(this.house).house, 1) != 0;
+                raiderGainedPowerToken = this.ingameGameState.changePowerTokens(this.house, 1) != 0 && !this.ingameGameState.isVassalHouse(this.house);
                 raidedHouseLostPowerToken = this.ingameGameState.changePowerTokens(raidedHouse, -1) != 0;
             }
 
@@ -113,7 +113,7 @@ export default class ResolveSingleRaidOrderGameState extends GameState<ResolveRa
 
             this.ingameGameState.log({
                 type: "raid-done",
-                raider: this.ingameGameState.getControllerOfHouse(this.house).house.id,
+                raider: this.house.id,
                 raidee: raidedHouse.id,
                 raiderRegion: orderRegion.id,
                 raidedRegion: targetRegion.id,


### PR DESCRIPTION
...and a commander doesn't earn a Power token from a raid of their vassal.