### PR TITLE
Show the bidding results in the GameState panel

### DIFF
--- a/agot-bg-game-server/src/client/GameLogListComponent.tsx
+++ b/agot-bg-game-server/src/client/GameLogListComponent.tsx
@@ -26,6 +26,8 @@ import HouseCard from "../common/ingame-game-state/game-data-structure/house-car
 import houseCardAbilities from "../common/ingame-game-state/game-data-structure/house-card/houseCardAbilities";
 import BetterMap from "../utils/BetterMap";
 import { tidesOfBattleCards } from "../common/ingame-game-state/game-data-structure/static-data-structure/tidesOfBattleCards";
+import HouseNumberResultsComponent from "./HouseNumberResultsComponent";
+import SimpleInfluenceIconComponent from "./game-state-panel/utils/SimpleInfluenceIconComponent";
 
 interface GameLogListComponentProps {
     ingameGameState: IngameGameState;
@@ -254,22 +256,13 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                         </Row>
                     </>
                 );
-            case "wildling-bidding":
-                const results: [number, House[]][] = data.results.map(([bid, hids]) => [bid, hids.map(hid => this.game.houses.get(hid))]);
+            case "wildling-bidding": {
+                const bids = _.flatMap(data.results.map(([bid, hids]) => hids.map(hid => [this.game.houses.get(hid), bid] as [House, number])));
 
                 return (
                     <>
-                        Wildling bidding results for Wildling Threat <b>{data.wildlingStrength}</b>:
-                        <table cellPadding="5">
-                            <tbody>
-                                {results.map(([bid, houses]) => houses.map(h => (
-                                    <tr key={`bid_${h.id}`}>
-                                        <td>{h.name}</td>
-                                        <td>{bid}</td>
-                                    </tr>
-                                )))}
-                            </tbody>
-                        </table>
+                        <p>Wildling bidding results for Wildling Threat <b>{data.wildlingStrength}</b>:</p>
+                        <div className="mt-1"><HouseNumberResultsComponent results={bids} key="wildlings"></HouseNumberResultsComponent></div>
                         {data.nightsWatchVictory ? (
                             <>The <b>Night&apos;s Watch</b> won!</>
                         ) : (
@@ -277,7 +270,7 @@ export default class GameLogListComponent extends Component<GameLogListComponent
                         )}
                     </>
                 );
-
+            }
             case "lowest-bidder-chosen": {
                 const lowestBidder = this.game.houses.get(data.lowestBidder);
 
@@ -563,25 +556,25 @@ export default class GameLogListComponent extends Component<GameLogListComponent
 
                 return <>
                     <p>
-                        Final order for {this.game.getNameInfluenceTrack(data.trackerI)}: {
-                        joinReactNodes(finalOrder.map(h => <b key={`cok_final_${h.id}`}>{h.name}</b>), ", ")}
+                        Final order of <b>{this.game.getNameInfluenceTrack(data.trackerI)}</b> track:
                     </p>
+                    <Row className="mb-2 mt-1">
+                        {finalOrder.map(h => <Col xs="auto" key={`cok_final_${h.id}`}><SimpleInfluenceIconComponent house={h}/></Col>)}
+                    </Row>
                 </>;
 
-            case "clash-of-kings-bidding-done":
-                const bids = _.flatMap(data.results.map(([bid, hids]) => hids.map(hid => [bid, this.game.houses.get(hid)] as [number, House])));
+            case "clash-of-kings-bidding-done": {
+                const bids = _.flatMap(data.results.map(([bid, hids]) => hids.map(hid => [this.game.houses.get(hid), bid] as [House, number])));
 
                 return <>
                     <p>
-                        Houses bid for the {this.game.getNameInfluenceTrack(data.trackerI)}:
+                        Houses bid for <b>{this.game.getNameInfluenceTrack(data.trackerI)}</b> track:
                     </p>
-                    <ul>
-                        {bids.map(([bid, house]) => (
-                            <li key={`cok_bid_done_${house.id}`}><b>{house.name}</b> bid <b>{bid}</b></li>
-                        ))}
-                    </ul>
+                    <Row className="mb-1 mt-2">
+                        <HouseNumberResultsComponent results={bids} key={`cok_${data.trackerI}`}/>
+                    </Row>
                 </>;
-
+            }
             case "wildling-strength-trigger-wildlings-attack":
                 return <>
                     <b>Wildling Threat</b> reached <b>{data.wildlingStrength}</b>, triggering a <b>Wildling Attack</b>
@@ -1153,16 +1146,8 @@ export default class GameLogListComponent extends Component<GameLogListComponent
 
                 return (
                 <>
-                    Supply levels have been adjusted:
-                    <table cellPadding="5">
-                        <tbody>
-                            {supplies.map(([house, supply]) => (
-                                <tr key={`supply_${house.id}`}>
-                                    <td>{house.name}</td>
-                                    <td>{supply}</td>
-                                </tr>))}
-                        </tbody>
-                    </table>
+                    <p>Supply levels have been adjusted:</p>
+                    <div className="mt-1"><HouseNumberResultsComponent results={supplies} key="supply"/></div>
                 </>);
             case "player-replaced": {
                 const oldUser = this.props.ingameGameState.entireGame.users.get(data.oldUser);

--- a/agot-bg-game-server/src/client/HouseNumberResultsComponent.tsx
+++ b/agot-bg-game-server/src/client/HouseNumberResultsComponent.tsx
@@ -1,0 +1,24 @@
+import { Component, ReactNode } from "react";
+import React from "react";
+import House from "../common/ingame-game-state/game-data-structure/House";
+import SimpleInfluenceIconComponent from "./game-state-panel/utils/SimpleInfluenceIconComponent";
+import { Col, Row } from "react-bootstrap";
+
+interface HouseNumberResultsProps {
+    results: [House, number][];
+    key?: string;
+}
+
+export default class HouseNumberResultsComponent extends Component<HouseNumberResultsProps> {
+    render(): ReactNode {
+        return <Row>
+            {this.props.results.map(([house, result]) => (
+            <Col xs="auto" key={`house-number-result-for-${house.id}`} className="d-flex flex-md-column align-items-center">
+                <div className="mb-2">
+                    <SimpleInfluenceIconComponent house={house}/>
+                </div>
+                <div className="text-center" style={{fontSize: "18px", marginBottom: "5px"}}>{result}</div>
+            </Col>))}
+        </Row>;
+    }
+}

--- a/agot-bg-game-server/src/client/LobbyComponent.tsx
+++ b/agot-bg-game-server/src/client/LobbyComponent.tsx
@@ -9,7 +9,6 @@ import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
 import ListGroup from "react-bootstrap/ListGroup";
 import ListGroupItem from "react-bootstrap/ListGroupItem";
-import houseInfluenceImages from "./houseInfluenceImages";
 import classNames = require("classnames");
 import ChatComponent from "./chat-client/ChatComponent";
 import GameSettingsComponent from "./GameSettingsComponent";
@@ -21,6 +20,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {faTimes} from "@fortawesome/free-solid-svg-icons/faTimes";
 import UserLabel from "./UserLabel";
 import EntireGame from "../common/EntireGame";
+import SimpleInfluenceIconComponent from "./game-state-panel/utils/SimpleInfluenceIconComponent";
 
 interface LobbyComponentProps {
     gameClient: GameClient;
@@ -59,9 +59,7 @@ export default class LobbyComponent extends Component<LobbyComponentProps> {
                                     <ListGroupItem key={h.id} style={{opacity: this.isHouseAvailable(h) ? 1 : 0.3}}>
                                         <Row className="align-items-center">
                                             {!this.randomHouses && <Col xs="auto">
-                                                <div className="influence-icon"
-                                                     style={{backgroundImage: `url(${houseInfluenceImages.get(h.id)})`}}>
-                                                </div>
+                                                <SimpleInfluenceIconComponent house={h}/>
                                             </Col>}
                                             <Col>
                                                 <div>

--- a/agot-bg-game-server/src/client/UserLabel.tsx
+++ b/agot-bg-game-server/src/client/UserLabel.tsx
@@ -24,7 +24,7 @@ interface UserLabelProps {
 // eslint-disable-next-line react/display-name
 const DropdownContainer: FunctionComponent<{onClick: (e: any) => void}> = React.forwardRef(
     // eslint-disable-next-line react/prop-types
-    ({children, onClick}) => <a className="text-body" href="" onClick={e => {e.preventDefault(); onClick(e)}}>
+    ({children, onClick}, _ref) => <a className="text-body" href="" onClick={e => {e.preventDefault(); onClick(e)}}>
         {children}
     </a>
 );

--- a/agot-bg-game-server/src/client/VoteComponent.tsx
+++ b/agot-bg-game-server/src/client/VoteComponent.tsx
@@ -6,13 +6,13 @@ import React from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Spinner from "react-bootstrap/Spinner";
-import houseInfluenceImages from "./houseInfluenceImages";
 import voteImage from "../../public/images/icons/vote.svg";
 import Button from "react-bootstrap/Button";
 import {faCheck} from "@fortawesome/free-solid-svg-icons/faCheck";
 import {faBan} from "@fortawesome/free-solid-svg-icons/faBan";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
+import SimpleInfluenceIconComponent from "./game-state-panel/utils/SimpleInfluenceIconComponent";
 
 interface VoteComponentProps {
     vote: Vote;
@@ -45,9 +45,7 @@ export default class VoteComponent extends Component<VoteComponentProps> {
                                 {this.vote.participatingPlayers.map(p => (
                                     <Col xs={"auto"} key={p.user.id}>
                                         <div className="mb-2" key={p.user.id}>
-                                            <div className="influence-icon"
-                                                style={{backgroundImage: `url(${houseInfluenceImages.get(p.house.id)})`}}>
-                                            </div>
+                                            <SimpleInfluenceIconComponent house={p.house}/>
                                         </div>
                                         <div className="text-center">
                                             {this.vote.votes.has(p.house) ? (

--- a/agot-bg-game-server/src/client/game-state-panel/ResolveTiesComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ResolveTiesComponent.tsx
@@ -10,10 +10,11 @@ import GameStateComponentProps from "./GameStateComponentProps";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Button from "react-bootstrap/Button";
-import houseInfluenceImages from "../houseInfluenceImages";
 import {faAngleLeft} from "@fortawesome/free-solid-svg-icons/faAngleLeft";
 import {faAngleRight} from "@fortawesome/free-solid-svg-icons/faAngleRight";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import SimpleInfluenceIconComponent from "./utils/SimpleInfluenceIconComponent";
+import HouseNumberResultsComponent from "../HouseNumberResultsComponent";
 
 @observer
 export default class ResolveTiesComponent extends Component<GameStateComponentProps<ResolveTiesGameState>> {
@@ -26,6 +27,7 @@ export default class ResolveTiesComponent extends Component<GameStateComponentPr
     }
 
     render(): ReactNode {
+        const results = _.flatMap(this.props.gameState.bidResults.map(([bid, houses]) => houses.map(h => [h, bid] as [House, number])));
         return (
             <>
                 <Col xs={12}>
@@ -38,9 +40,7 @@ export default class ResolveTiesComponent extends Component<GameStateComponentPr
                                 {this.currentOrdering.map((h, i) => (
                                     <Col xs="auto" key={h.id} className="d-flex flex-md-column align-items-center">
                                         <div className="mb-2">
-                                            <div className="influence-icon"
-                                                 style={{backgroundImage: `url(${houseInfluenceImages.get(h.id)})`}}>
-                                            </div>
+                                            <SimpleInfluenceIconComponent house={h}/>
                                         </div>
                                         <div className="text-center" style={{fontSize: "18px", marginBottom: "5px"}}>{this.props.gameState.getBidOfHouse(h)}</div>
                                         <div className="btn-group btn-group-xs">
@@ -67,9 +67,13 @@ export default class ResolveTiesComponent extends Component<GameStateComponentPr
                             <Button onClick={() => this.submit()}>Resolve</Button>
                         </Col>
                     </>
-                ) : (
+                ) : <>
+                    <Col xs={12}>
+                        <p>Bidding results:</p>
+                        <HouseNumberResultsComponent results={results} key="cok"/>
+                    </Col>
                     <Col xs={12} className="text-center">Waiting for {this.props.gameState.decider.name}...</Col>
-                )}
+                </>}
             </>
         );
     }

--- a/agot-bg-game-server/src/client/game-state-panel/utils/HouseCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/HouseCardComponent.tsx
@@ -4,6 +4,7 @@ import HouseCard from "../../../common/ingame-game-state/game-data-structure/hou
 import houseCardImages from "../../houseCardImages";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import classNames = require("classnames");
+import ImagePopover from "./ImagePopover";
 
 interface HouseCardComponentProps {
     houseCard: HouseCard;
@@ -16,13 +17,8 @@ interface HouseCardComponentProps {
 @observer
 export default class HouseCardComponent extends Component<HouseCardComponentProps> {
     render(): ReactNode {
-        return (
-            <OverlayTrigger
-                overlay={
-                    <div className="vertical-game-card" style={{
-                        backgroundImage: `url(${houseCardImages.get(this.props.houseCard.id)})`
-                    }}/>
-                }
+        return <OverlayTrigger
+                overlay={this.renderPopover()}
                 popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
                 delay={{show: 120, hide: 0}}
                 placement="auto"
@@ -37,7 +33,12 @@ export default class HouseCardComponent extends Component<HouseCardComponentProp
                     src={houseCardImages.get(this.props.houseCard.id)}
                     onClick={() => this.props.onClick ? this.props.onClick() : undefined}
                 />
-            </OverlayTrigger>
-        );
+            </OverlayTrigger>;
+    }
+
+    private renderPopover(): ReactNode {
+        return <ImagePopover className="vertical-game-card" style={{
+            backgroundImage: `url(${houseCardImages.get(this.props.houseCard.id)})`}}
+        />;
     }
 }

--- a/agot-bg-game-server/src/client/game-state-panel/utils/ImagePopover.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/ImagePopover.tsx
@@ -1,0 +1,37 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+export interface ImagePopoverProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  arrowProps?: any;
+  scheduleUpdate?: any;
+  outOfBoundaries?: any;
+}
+
+const ImagePopover = React.forwardRef<HTMLDivElement, ImagePopoverProps>(
+  (
+    {
+      className,
+      style,
+      arrowProps: _,
+      scheduleUpdate: _2,
+      outOfBoundaries: _3,
+      ...props
+    }: ImagePopoverProps,
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        style={style}
+        className={classNames(className)}
+        {...props}
+      >
+      </div>
+    );
+  },
+);
+
+ImagePopover.displayName="ImagePopover";
+
+export default ImagePopover;

--- a/agot-bg-game-server/src/client/game-state-panel/utils/InfluenceIconComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/InfluenceIconComponent.tsx
@@ -28,18 +28,16 @@ export default class InfluenceIconComponent extends Component<InfluenceIconCompo
     }
 
     render(): ReactNode {
-        return (
-            <OverlayTrigger overlay={
-                    <Tooltip id="influence-icon">
-                        <b>{this.house.name}</b>
-                    </Tooltip>
-                }
-                placement="bottom"
-            >
-                <div className={classNames("influence-icon", {"medium-outline": this.ingame.game.getTokenHolder(this.track) == this.house})}
-                    style={{backgroundImage: `url(${houseInfluenceImages.get(this.house.id)})`}}>
-                </div>
-            </OverlayTrigger>
-        );
+        return <OverlayTrigger overlay={
+                <Tooltip id="influence-icon">
+                    <b>{this.house.name}</b>
+                </Tooltip>
+            }
+            placement="bottom"
+        >
+            <div className={classNames("influence-icon", {"medium-outline": this.ingame.game.getTokenHolder(this.track) == this.house})}
+                style={{backgroundImage: `url(${houseInfluenceImages.get(this.house.id)})`}}>
+            </div>
+        </OverlayTrigger>;
     }
 }

--- a/agot-bg-game-server/src/client/game-state-panel/utils/SimpleInfluenceIconComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/SimpleInfluenceIconComponent.tsx
@@ -1,0 +1,29 @@
+import {Component, default as React, ReactNode} from "react";
+import Tooltip from "react-bootstrap/Tooltip";
+import houseInfluenceImages from "../../houseInfluenceImages";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import { LobbyHouse } from "../../../common/lobby-game-state/LobbyGameState";
+
+interface SimpleInfluenceIconComponentProps {
+    house: LobbyHouse;
+}
+
+export default class SimpleInfluenceIconComponent extends Component<SimpleInfluenceIconComponentProps> {
+    get house(): LobbyHouse {
+        return this.props.house;
+    }
+
+    render(): ReactNode {
+        return <OverlayTrigger overlay={
+                <Tooltip id="influence-icon">
+                    <b>{this.house.name}</b>
+                </Tooltip>
+            }
+            placement="bottom"
+            popperConfig={{ modifiers: { preventOverflow: { boundariesElement: "viewport" } } }}
+        >
+            <div className="influence-icon"
+                style={{backgroundImage: `url(${houseInfluenceImages.get(this.house.id)})`}}/>
+        </OverlayTrigger>;
+    }
+}

--- a/agot-bg-game-server/src/client/game-state-panel/utils/TidesOfBattleCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/TidesOfBattleCardComponent.tsx
@@ -3,6 +3,7 @@ import {observer} from "mobx-react";
 import { TidesOfBattleCard } from "../../../common/ingame-game-state/game-data-structure/static-data-structure/tidesOfBattleCards";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import tidesOfBattleImages from "../../../client/tidesOfBattleImages";
+import ImagePopover from "./ImagePopover";
 
 interface TidesOfBattleCardComponentProps {
     tidesOfBattleCard: TidesOfBattleCard;
@@ -11,24 +12,24 @@ interface TidesOfBattleCardComponentProps {
 @observer
 export default class TidesOfBattleCardComponent extends Component<TidesOfBattleCardComponentProps> {
     render(): ReactNode {
-        return (
-            <OverlayTrigger
-                overlay={
-                    <div className="vertical-game-card small" style={{
-                        backgroundImage: `url(${tidesOfBattleImages.get(this.props.tidesOfBattleCard.id)})`
-                    }}/>
-                }
-                popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
-                delay={{show: 120, hide: 0}}
-                placement="auto"
-            >
-                <div
-                    className="vertical-game-card hover-weak-outline tiny"
-                    style={{
-                        backgroundImage: `url(${tidesOfBattleImages.get(this.props.tidesOfBattleCard.id)})`
-                    }}
-                />
-            </OverlayTrigger>
-        );
+        return <OverlayTrigger
+            overlay={this.renderPopover()}
+            popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
+            delay={{show: 120, hide: 0}}
+            placement="auto"
+        >
+            <div
+                className="vertical-game-card hover-weak-outline tiny"
+                style={{
+                    backgroundImage: `url(${tidesOfBattleImages.get(this.props.tidesOfBattleCard.id)})`
+                }}
+            />
+        </OverlayTrigger>;
+    }
+
+    renderPopover(): ReactNode {
+        return <ImagePopover className="vertical-game-card small" style={{
+            backgroundImage: `url(${tidesOfBattleImages.get(this.props.tidesOfBattleCard.id)})`}}
+        />;
     }
 }

--- a/agot-bg-game-server/src/client/game-state-panel/utils/WesterosCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/WesterosCardComponent.tsx
@@ -5,6 +5,7 @@ import {observer} from "mobx-react";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import WesterosCardType from "../../../common/ingame-game-state/game-data-structure/westeros-card/WesterosCardType";
 import westerosCardImages from "../../westerosCardImages";
+import ImagePopover from "./ImagePopover";
 
 interface WesterosCardProps {
     cardType: WesterosCardType;
@@ -19,28 +20,26 @@ interface WesterosCardProps {
 @observer
 export default class WesterosCardComponent extends Component<WesterosCardProps> {
     render(): ReactNode {
-        return (
-            <OverlayTrigger
-                overlay={
-                    this.props.tooltip ? <div
-                        className="horizontal-game-card"
-                        style={{
-                            backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.westerosDeckI).get(this.props.cardType.id)})` : undefined
-                        }}
-                    /> : <div/>
-                }
-                popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
-                delay={{show: 120, hide: 0}}
-                placement="auto"
-            >
-                <div
-                    className={classNames("horizontal-game-card hover-weak-outline", this.props.size, this.props.classNames, {"medium-outline hover-strong-outline": this.props.selected})}
-                    style={{
-                        backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.westerosDeckI).get(this.props.cardType.id)})` : undefined
-                    }}
-                    onClick={() => this.props.onClick ? this.props.onClick() : undefined}
-                />
-            </OverlayTrigger>
-        );
+        return <OverlayTrigger
+            overlay={this.renderPopover()}
+            popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
+            delay={{show: 120, hide: 0}}
+            placement="auto"
+        >
+            <div
+                className={classNames("horizontal-game-card hover-weak-outline", this.props.size, this.props.classNames, {"medium-outline hover-strong-outline": this.props.selected})}
+                style={{
+                    backgroundImage: this.props.cardType ? `url(${westerosCardImages.get(this.props.westerosDeckI).get(this.props.cardType.id)})` : undefined
+                }}
+                onClick={() => this.props.onClick ? this.props.onClick() : undefined}
+            />
+        </OverlayTrigger>;
+    }
+
+    private renderPopover(): ReactNode {
+        return this.props.tooltip ?
+            <ImagePopover className="horizontal-game-card"
+                style={{backgroundImage: `url(${westerosCardImages.get(this.props.westerosDeckI).get(this.props.cardType.id)})`}}/>
+            : <ImagePopover className="invisible"/>
     }
 }

--- a/agot-bg-game-server/src/client/game-state-panel/utils/WildlingCardComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/WildlingCardComponent.tsx
@@ -6,6 +6,7 @@ import WildlingCardType from "../../../common/ingame-game-state/game-data-struct
 import wildlingCardImages from "../../wildlingCardImages";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import {Placement} from "react-bootstrap/Overlay";
+import ImagePopover from "./ImagePopover";
 
 interface WildlingCardProps {
     cardType: WildlingCardType;
@@ -17,27 +18,26 @@ interface WildlingCardProps {
 @observer
 export default class WildlingCardComponent extends Component<WildlingCardProps> {
     render(): ReactNode {
-        return (
-            <OverlayTrigger
-                overlay={
-                    this.props.tooltip ? <div
-                        className="vertical-game-card"
-                        style={{
-                            backgroundImage: this.props.cardType ? `url(${wildlingCardImages.get(this.props.cardType.id)})` : undefined
-                        }}
-                    /> : <div/>
-                }
-                delay={{show: 120, hide: 0}}
-                popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
-                placement={this.props.placement}
-            >
-                <div
-                    className={classNames("vertical-game-card hover-weak-outline", this.props.size, {"slot": this.props.cardType == null})}
-                    style={{
-                        backgroundImage: this.props.cardType ? `url(${wildlingCardImages.get(this.props.cardType.id)})` : undefined
-                    }}
-                />
-            </OverlayTrigger>
-        );
+        return <OverlayTrigger
+            overlay={this.renderPopover()}
+            delay={{show: 120, hide: 0}}
+            popperConfig={{modifiers: {preventOverflow: {boundariesElement: "viewport"}}}}
+            placement={this.props.placement}
+        >
+            <div
+                className={classNames("vertical-game-card hover-weak-outline", this.props.size, {"slot": this.props.cardType == null})}
+                style={{
+                    backgroundImage: this.props.cardType ? `url(${wildlingCardImages.get(this.props.cardType.id)})` : undefined
+                }}
+            />
+        </OverlayTrigger>;
+    }
+
+    renderPopover(): ReactNode {
+        return this.props.tooltip ? <ImagePopover className="vertical-game-card"
+            style={{
+                backgroundImage: `url(${wildlingCardImages.get(this.props.cardType.id)})`}}
+            />
+            : <ImagePopover className="invisible"/>;
     }
 }

--- a/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
@@ -45,11 +45,17 @@ import TheHordeDescendsNightsWatchVictoryComponent from "./TheHordeDescendsNight
 import ListGroupItem from "react-bootstrap/ListGroupItem";
 import WildlingCardComponent from "../utils/WildlingCardComponent";
 import joinReactNodes from "../../../client/utils/joinReactNodes";
+import House from "../../../common/ingame-game-state/game-data-structure/House";
+import _ from "lodash";
+import HouseNumberResultsComponent from "../../../client/HouseNumberResultsComponent";
 
 @observer
 export default class WildlingsAttackComponent extends Component<GameStateComponentProps<WildlingsAttackGameState>> {
     render(): ReactNode {
         const wildlingCardType = this.props.gameState.wildlingCard ? this.props.gameState.wildlingCard.type : null;
+        const results = this.props.gameState.biddingResults
+            ? _.flatMap(this.props.gameState.biddingResults.map(([bid, houses]) => houses.map(h => [h, bid] as [House, number])))
+            : null;
         return (
             <>
                 {wildlingCardType && (
@@ -63,14 +69,19 @@ export default class WildlingsAttackComponent extends Component<GameStateCompone
                 )}
                 <ListGroupItem>
                     <Row>
-                        {this.props.gameState.childGameState instanceof BiddingGameState && (
+                        {this.props.gameState.childGameState instanceof BiddingGameState ? (
                             <Col xs={12}>
                                 <b>All houses</b>{this.props.gameState.excludedHouses.length >0 &&
                                 (<> except {joinReactNodes(this.props.gameState.excludedHouses.map(h =>
                                 <b key={h.id}>{h.name}</b>), ", ")}</>)} bid Power tokens to overcome the
                                 Wildlings which are attacking with a strength of <b>{this.props.gameState.game.wildlingStrength}</b>!
                             </Col>
-                        )}
+                        ) : results ?
+                            <Col xs={12}>
+                                <p>Bidding results:</p>
+                                <HouseNumberResultsComponent results={results} key="wildlings"/>
+                            </Col>
+                        : <></>}
                         {renderChildGameState<WildlingsAttackGameState>(this.props, [
                             [SimpleChoiceGameState, SimpleChoiceComponent],
                             [BiddingGameState, BiddingComponent],

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -436,7 +436,7 @@ export default class Game {
             structuresCountNeededToWin: this.structuresCountNeededToWin,
             maxTurns: this.maxTurns,
             maxPowerTokens: this.maxPowerTokens,
-            clientNextWidllingCardId: (admin || knowsNextWildlingCard) ? this.wildlingDeck[0].id : null,
+            clientNextWildlingCardId: (admin || knowsNextWildlingCard) ? this.wildlingDeck[0].id : null,
             revealedWesterosCards: this.revealedWesterosCards,
             vassalRelations: this.vassalRelations.map((key, value) => [key.id, value.id]),
             vassalHouseCards: this.vassalHouseCards.entries.map(([hcid, hc]) => [hcid, hc.serializeToClient()]),
@@ -465,7 +465,7 @@ export default class Game {
         game.maxTurns = data.maxTurns;
         game.maxPowerTokens = data.maxPowerTokens;
         game.revealedWesterosCards = data.revealedWesterosCards;
-        game.clientNextWildlingCardId = data.clientNextWidllingCardId;
+        game.clientNextWildlingCardId = data.clientNextWildlingCardId;
         game.vassalRelations = new BetterMap(data.vassalRelations.map(([vid, hid]) => [game.houses.get(vid), game.houses.get(hid)]));
         game.vassalHouseCards = new BetterMap(data.vassalHouseCards.map(([hcid, hc]) => [hcid, HouseCard.deserializeFromServer(hc)]));
         game.houseCardsForDrafting = new BetterMap(data.houseCardsForDrafting.map(([hcid, hc]) => [hcid, HouseCard.deserializeFromServer(hc)]));
@@ -493,7 +493,7 @@ export interface SerializedGame {
     maxTurns: number;
     maxPowerTokens: number;
     revealedWesterosCards: number;
-    clientNextWidllingCardId: number | null;
+    clientNextWildlingCardId: number | null;
     vassalRelations: [string, string][];
     vassalHouseCards: [string, SerializedHouseCard][];
     houseCardsForDrafting: [string, SerializedHouseCard][];

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -23,7 +23,7 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | UpdateWesterosDecks | UpdateConnectionStatus | VoteStarted | VoteCancelled | VoteDone | PlayerReplaced
     | CrowKillersStepChanged | ManipulateCombatHouseCard | ChangeCombatTidesOfBattleCard
     | VassalRelations | UpdateHouseCardModifier | UpdateHouseCards | UpdateHouseCardsForDrafting | UpdateCombatStats
-    | UpdateDraftIndices;
+    | UpdateDraftIndices | RevealBids;
 
 interface AuthenticationResponse {
     type: "authenticate-response";
@@ -340,4 +340,9 @@ interface UpdateDraftIndices {
     type: "update-draft-indices";
     rowIndex: number;
     columnIndex: number;
+}
+
+interface RevealBids {
+    type: "reveal-bids";
+    bids: [number, string[]][];
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -829,6 +829,17 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "32",
+        migrate: (serializedGame: any) => {
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+                ingame.game.clientNextWildlingCardId = ingame.game.clientNextWidllingCardId;
+            }
+
+            return serializedGame;
+        }
     }
 ];
 


### PR DESCRIPTION
Closes #990 
Fix #981 


And finally this PR fixes following warnings on client-side which have annoyed me for a long time already:

`Warning: forwardRef render functions accept two parameters: props and ref. Did you forget to use the ref parameter?`
and
```Warning: React does not recognize the `arrowProps` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `arrowprops` instead. If you accidentally passed it from a parent component, remove it from the DOM element.```