### PR TITLE
Fix multiple things

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
@@ -394,6 +394,7 @@ export default class CombatGameState extends GameState<
         });
     }
 
+    // This method returns true if it sets UseValyrianSteelBladeGameState as new childGameState
     proceedValyrianSteelBladeUsage(): boolean {
         // First the VSB can be used to change the drawn ToB card, so if the current childGameState is not UseVsbGameState ist must be for ToB change
         const forNewTidesOfBattleCard = this.isTidesOfBattleCardsActive && !(this.childGameState instanceof UseValyrianSteelBladeGameState);
@@ -405,7 +406,8 @@ export default class CombatGameState extends GameState<
         // Check if the sword has not been used this round
         if (!this.game.valyrianSteelBladeUsed) {
             // Check if VSB holder already decided to use (burn) the VSB during choose house card game state
-            if (this.valyrianSteelBladeUser != null) {
+            // And check as well the blade user is still the VSB holder (Doran!)
+            if (this.valyrianSteelBladeUser == this.game.valyrianSteelBladeHolder) {
                 this.game.valyrianSteelBladeUsed = true;
                 this.ingameGameState.log({
                     type: "combat-valyrian-sword-used",
@@ -419,6 +421,8 @@ export default class CombatGameState extends GameState<
                 });
 
                 return false;
+            } else {
+                this.valyrianSteelBladeUser = null;
             }
 
             // Check if one of the two participants can use the sword.

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
@@ -543,8 +543,8 @@ export default class CombatGameState extends GameState<
         return this.getCommandedHouseInCombat(player.house);
     }
 
-    proceedToChooseGeneral(): void {
-        this.setChildGameState(new ChooseHouseCardGameState(this)).firstStart();
+    proceedToChooseGeneral(choosableHouseCards: BetterMap<House, HouseCard[]> | null = null): void {
+        this.setChildGameState(new ChooseHouseCardGameState(this)).firstStart(choosableHouseCards);
     }
 
     proceedNextSupportDeclaration(): boolean {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/choose-house-card-game-state/ChooseHouseCardGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/choose-house-card-game-state/ChooseHouseCardGameState.ts
@@ -32,15 +32,26 @@ export default class ChooseHouseCardGameState extends GameState<CombatGameState>
         return this.combatGameState.ingameGameState;
     }
 
-    firstStart(): void {
+    // To support assigning the same vassal cards after Refuse support has been triggered
+    // we allow passing the previous chosen house cards
+    firstStart(choosableHouseCards: BetterMap<House, HouseCard[]> | null = null): void {
         // Setup the choosable house cards
-        const vassalHouseCards = _.shuffle(this.ingameGameState.game.vassalHouseCards.values);
+        let vassalHouseCards = _.shuffle(this.ingameGameState.game.vassalHouseCards.values);
+        if (choosableHouseCards) {
+            vassalHouseCards = _.without(vassalHouseCards, ...(_.flatMap(choosableHouseCards.values)));
+        }
+
         this.choosableHouseCards = new BetterMap(this.combatGameState.houseCombatDatas.keys.map(h => {
             // If the house a player-controlled house, return the available cards.
             // If it a vassal, then randomly choose 3 of them.
-            const houseCards = (!this.ingameGameState.isVassalHouse(h)
-                ? h.houseCards.values.filter(hc => hc.state == HouseCardState.AVAILABLE)
-                : vassalHouseCards.splice(0, 3)).sort((a, b) => a.combatStrength - b.combatStrength);
+            let houseCards: HouseCard[];
+            if (choosableHouseCards && choosableHouseCards.has(h)) {
+                houseCards = choosableHouseCards.get(h);
+            } else {
+                houseCards = (!this.ingameGameState.isVassalHouse(h)
+                    ? h.houseCards.values.filter(hc => hc.state == HouseCardState.AVAILABLE)
+                    : vassalHouseCards.splice(0, 3)).sort((a, b) => a.combatStrength - b.combatStrength);
+            }
 
             // Assign the chosen house cards to the vassal house as some abilities require a hand during resolution
             if (this.ingameGameState.isVassalHouse(h)) {
@@ -140,8 +151,11 @@ export default class ChooseHouseCardGameState extends GameState<CombatGameState>
                 houseId: commandedHouse.id
             });
 
+            const vassals = this.choosableHouseCards.keys.filter(h => this.ingameGameState.isVassalHouse(h));
+            const choosableHouseCards = vassals.length > 0 ? new BetterMap(vassals.map(h => [h, this.choosableHouseCards.get(h)])) : null;
+
             // Reset combatGameState.clientGameState to retrigger ChooseHouseCardGameState
-            this.combatGameState.proceedToChooseGeneral();
+            this.combatGameState.proceedToChooseGeneral(choosableHouseCards);
         }
     }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -410,7 +410,7 @@ export default class Game {
     serializeToClient(admin: boolean, knowsNextWildlingCard: boolean): SerializedGame {
         return {
             lastUnitId: this.lastUnitId,
-            houses: this.houses.values.map(h => h.serializeToClient()),
+            houses: this.houses.values.map(h => h.serializeToClient(admin, this.ingame.isVassalHouse(h))),
             world: this.world.serializeToClient(),
             turn: this.turn,
             ironThroneTrack: this.ironThroneTrack.map(h => h.id),

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/House.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/House.ts
@@ -26,13 +26,13 @@ export default class House {
         this.supplyLevel = supplyLevel;
     }
 
-    serializeToClient(): SerializedHouse {
+    serializeToClient(admin: boolean, isVassalHouse: boolean): SerializedHouse {
         return {
             id: this.id,
             name: this.name,
             color: this.color,
             knowsNextWildlingCard: this.knowsNextWildlingCard,
-            houseCards: this.houseCards.entries.map(([houseCardId, houseCard]) => [houseCardId, houseCard.serializeToClient()]),
+            houseCards: (admin || !isVassalHouse) ? this.houseCards.entries.map(([houseCardId, houseCard]) => [houseCardId, houseCard.serializeToClient()]) : [],
             unitLimits: this.unitLimits.map((unitType, limit) => [unitType.id, limit]),
             powerTokens: this.powerTokens,
             supplyLevel: this.supplyLevel


### PR DESCRIPTION
Fix #1051 
Fix #1050 

During fixing vassal house cards after refuse support I realized that the randomly picked vassal house cards can be revealed by examining the game state tree during combat. This is also fixed with this PR.