### PR TITLE
Fix quotation marks in tooltip

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/utils/SupplyTrackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/utils/SupplyTrackComponent.tsx
@@ -27,7 +27,7 @@ export default class SupplyTrackComponent extends Component<SupplyTrackComponent
                             Each supply track column contains a list of numbers illustrating the
                             maximum size and count of each player&apos;s armies. (An army is made up
                             of two or more units within the same land or sea area.) The supply
-                            track is updated from game effects, such as the &quotSupply&quot Westeros
+                            track is updated from game effects, such as the &quot;Supply&quot; Westeros
                             card. The updated supply position is determined by the number of
                             Supply icons printed in areas that the player controls.
                         </Tooltip>


### PR DESCRIPTION
The tooltip was using `&quotS` which does not render correctly.

Before:
https://i.imgur.com/oRhrFEj.png

After:
https://i.imgur.com/PFUSJC4.png

Tested in Chrome and Firefox on windows.