### PR TITLE
Move units-wounded to IngameGameState

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -542,6 +542,11 @@ export default class IngameGameState extends GameState<
                 to.units.set(u.id, u);
                 u.region = to;
             });
+        } else if (message.type == "units-wounded") {
+            const region = this.world.regions.get(message.regionId);
+            const units = message.unitIds.map(uid => region.units.get(uid));
+
+            units.forEach(u => u.wounded = true);
         } else if (message.type == "change-power-token") {
             const house = this.game.houses.get(message.houseId);
 

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
@@ -505,11 +505,6 @@ export default class CombatGameState extends GameState<
             const killedUnits = message.unitIds.map(uid => region.units.get(uid));
 
             killedUnits.forEach(u => region.units.delete(u.id));
-        } else if (message.type == "units-wounded") {
-            const region = this.world.regions.get(message.regionId);
-            const units = message.unitIds.map(uid => region.units.get(uid));
-
-            units.forEach(u => u.wounded = true);
         } else if (message.type == "change-combat-house-card") {
             const houseCards: [House, HouseCard | null][] = message.houseCardIds.map(([houseId, houseCardId]) => [
                 this.game.houses.get(houseId),


### PR DESCRIPTION
Solves #1256 partly.

This PR moves receiving `units-wounded` to `IngameGameState` which solves this specific scenario. There might be some more special situations which cause exactly the same behaviour with other packets.