### PR TITLE
Fix Westeros tooltip "Dark Wings Dark Words" and show IB and FFC tooltips on click...

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -916,10 +916,10 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                         <Col key={"westeros-deck-" + i + "-data"}>
                             {rc.map(([wc, count], j) =>
                                 <Row key={"westeros-deck-" + i + "-" + j + "-data"} className="m1 align-items-center">
-                                    <Col xs="auto" className="pr-0">
+                                    <Col xs="auto" style={{marginRight: "-20px"}}>
                                         {count > 1 ? count : <>&nbsp;</>}
                                     </Col>
-                                    <Col className="pl-0" style={{width: "130px", maxWidth: "130px"}}>
+                                    <Col className="pl-0" style={{width: "145px", maxWidth: "145px"}}>
                                         <WesterosCardComponent
                                             cardType={wc}
                                             westerosDeckI={i}

--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -209,11 +209,12 @@ export default class MapComponent extends Component<MapComponentProps> {
     private renderLoanCardDeck(ironBankView: StaticIronBankView | null): ReactNode {
         return ironBankView && <OverlayTrigger
             overlay={this.renderLoanCardsToolTip()}
+            trigger="click"
+            rootClose
             popperConfig={{ modifiers: [preventOverflow] }}
-            delay={{ show: 120, hide: 0 }}
             placement="auto"
         >
-            <div id="loan-card-deck" className="order-container" style={{
+            <div id="loan-card-deck" className="order-container clickable" style={{
                 left: ironBankView.deckSlot.point.x,
                 top: ironBankView.deckSlot.point.y
             }}>

--- a/agot-bg-game-server/src/client/ObjectivesInfoComponent.tsx
+++ b/agot-bg-game-server/src/client/ObjectivesInfoComponent.tsx
@@ -79,16 +79,18 @@ export default class ObjectivesInfoComponent extends Component<ObjectivesInfoCom
                         />
                     </Col>)}
             </Row>
-            <Row className="justify-content-center mt-4">
+            <Row className="justify-content-center mt-4 clickable">
                 <Col xs={12}>
                     <OverlayTrigger overlay={this.renderRulesTooltip()}
+                        trigger="click"
+                        rootClose
                         popperConfig={{ modifiers: [preventOverflow] }}
                         placement="auto">
                             <h5 className="mb-0 text-center">
                                 <FontAwesomeIcon
                                     style={{ fontSize: "20px" }}
                                     icon={faBookReader} />
-                                &nbsp;&nbsp;Rules&nbsp;&nbsp;
+                                <span className="px-2">Rules</span>
                                 <FontAwesomeIcon
                                     style={{ fontSize: "20px" }}
                                     icon={faQuestionCircle} />
@@ -100,30 +102,32 @@ export default class ObjectivesInfoComponent extends Component<ObjectivesInfoCom
     }
 
     renderRulesTooltip(): OverlayChildren {
-        return <Tooltip id="affc-rules-tooltip" className="tooltip-w-50">
-            <h5 className="text-center">Objectives</h5>
-            The A Feast for Crows scenario introduces a new way for players to score victory points. Players no longer use the Victory track to record the number of Castles and Strongholds they control.
-            Instead, each player now advances on the Victory track by completing the objectives described on his Objective cards, with the goal of being the first and only player to reach position 7.
-            <br/><br/>
-            <h5 className="text-center">Scoring and Supply</h5>
-            After each Action phase, players resolve these additional steps:<br/>
-            <ol>
-                <li><b>Update Supply:</b> In turn order, all players update their supply levels (as if they were resolving the &quot;Supply&quot; Westeros card in the core game) and then reconcile their armies.</li>
-                <li><b>Score Special Objectives:</b> Each round, during this step, each player may choose to score his Special Objective card (if the criterion described is fulfilled), moving his Victory Point token forward one space.</li>
-                <li><b>Score Other Objectives:</b> In turn order, each player may choose to score one Objective card of his choice from his objective hand (if the criterion described is fulfilled),
-                    placing the scored card faceup in his play areas and moving his Victory Point token forward a number of spaces equal to the number next to his House sigil on the scored card.
-                    Scored Objective cards remain faceup in a player&apos;s play area for the remainder of the game.<br/>Note, unlike Special Objective cards, these cards can only be scored once.</li>
-                <li><b>Draw Objective Cards:</b> Any player who does not have 3 Objective cards in his objective hand draws 1 new Objective card and adds it to his objective hand.</li>
-            </ol>
-            <br/><br/>
-            <h5 className="text-center">Winning the Game</h5>
-            After the Draw Objective Cards step, if any one player occupies position 7 of the Victory track, that player wins the game.
-            If, at this time, two or more players tie by occupying position 7 of the Victory track, the tied player who controls more total land areas wins.
-            If there is still a tie, the tied player who is highest on the Iron Throne Influence track wins.
-            <br/><br/>
-            <h5 className="text-center">FAQ</h5>
-            <i>Q: When playing A Feast for Crows, what are the tiebreakers at the end of Round 10?</i><br/>
-            A: If at the end of Round 10 no player has 7 victory points, the player with the most victory points who is in the highest position on the Iron Throne is the winner.
+        return <Tooltip id="affc-rules-tooltip" className="tooltip-w-30">
+            <Col>
+                <h5 className="text-center">Objectives</h5>
+                The A Feast for Crows scenario introduces a new way for players to score victory points. Players no longer use the Victory track to record the number of Castles and Strongholds they control.
+                Instead, each player now advances on the Victory track by completing the objectives described on his Objective cards, with the goal of being the first and only player to reach position 7.
+                <br/><br/>
+                <h5 className="text-center">Scoring and Supply</h5>
+                After each Action phase, players resolve these additional steps:<br/>
+                <ol>
+                    <li><b>Update Supply:</b> In turn order, all players update their supply levels (as if they were resolving the &quot;Supply&quot; Westeros card in the core game) and then reconcile their armies.</li>
+                    <li><b>Score Special Objectives:</b> Each round, during this step, each player may choose to score his Special Objective card (if the criterion described is fulfilled), moving his Victory Point token forward one space.</li>
+                    <li><b>Score Other Objectives:</b> In turn order, each player may choose to score one Objective card of his choice from his objective hand (if the criterion described is fulfilled),
+                        placing the scored card faceup in his play areas and moving his Victory Point token forward a number of spaces equal to the number next to his House sigil on the scored card.
+                        Scored Objective cards remain faceup in a player&apos;s play area for the remainder of the game.<br/>Note, unlike Special Objective cards, these cards can only be scored once.</li>
+                    <li><b>Draw Objective Cards:</b> Any player who does not have 3 Objective cards in his objective hand draws 1 new Objective card and adds it to his objective hand.</li>
+                </ol>
+                <br/><br/>
+                <h5 className="text-center">Winning the Game</h5>
+                After the Draw Objective Cards step, if any one player occupies position 7 of the Victory track, that player wins the game.
+                If, at this time, two or more players tie by occupying position 7 of the Victory track, the tied player who controls more total land areas wins.
+                If there is still a tie, the tied player who is highest on the Iron Throne Influence track wins.
+                <br/><br/>
+                <h5 className="text-center">FAQ</h5>
+                <i>Q: When playing A Feast for Crows, what are the tiebreakers at the end of Round 10?</i><br/>
+                A: If at the end of Round 10 no player has 7 victory points, the player with the most victory points who is in the highest position on the Iron Throne is the winner.
+            </Col>
         </Tooltip>;
     }
 }

--- a/agot-bg-game-server/src/client/style/custom.scss
+++ b/agot-bg-game-server/src/client/style/custom.scss
@@ -484,6 +484,10 @@ div.new-event {
   max-width: 50%;
 }
 
+.tooltip-w-30 > .tooltip-inner {
+  max-width: 30%;
+}
+
 .display-none {
   display: none;
 }


### PR DESCRIPTION
which keeps them open and allows easier scrolling and zooming.