### PR TITLE
Move notes from Player to User

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -686,23 +686,21 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                                         </Nav.Link>
                                     </Nav.Item>
                                 )}
-                                {this.authenticatedPlayer && (
-                                    <Nav.Item>
-                                        <Nav.Link eventKey="note">
-                                            <OverlayTrigger
-                                                overlay={<Tooltip id="note-tooltip">Personal note</Tooltip>}
-                                                placement="top"
-                                            >
-                                                <span>
-                                                    <FontAwesomeIcon
-                                                        style={{ color: "white" }}
-                                                        icon={faEdit} />
-                                                    {/* &nbsp;Notes */}
-                                                </span>
-                                            </OverlayTrigger>
-                                        </Nav.Link>
-                                    </Nav.Item>
-                                )}
+                                <Nav.Item>
+                                    <Nav.Link eventKey="note">
+                                        <OverlayTrigger
+                                            overlay={<Tooltip id="note-tooltip">Personal note</Tooltip>}
+                                            placement="top"
+                                        >
+                                            <span>
+                                                <FontAwesomeIcon
+                                                    style={{ color: "white" }}
+                                                    icon={faEdit} />
+                                                {/* &nbsp;Notes */}
+                                            </span>
+                                        </OverlayTrigger>
+                                    </Nav.Link>
+                                </Nav.Item>
                                 <Nav.Item>
                                     <Nav.Link eventKey="settings">
                                         <OverlayTrigger
@@ -779,11 +777,9 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                                         <ObjectivesInfoComponent ingame={this.ingame} gameClient={this.props.gameClient}/>
                                     </div>
                                 </Tab.Pane>
-                                {this.authenticatedPlayer && (
-                                    <Tab.Pane eventKey="note" className="h-100">
-                                        <NoteComponent gameClient={this.props.gameClient} ingame={this.props.gameState} />
-                                    </Tab.Pane>
-                                )}
+                                <Tab.Pane eventKey="note" className="h-100">
+                                    <NoteComponent gameClient={this.props.gameClient} ingame={this.props.gameState} />
+                                </Tab.Pane>
                                 {this.getPrivateChatRooms().map(({ roomId }) => (
                                     <Tab.Pane eventKey={roomId} key={roomId} className="h-100">
                                         <ChatComponent gameClient={this.props.gameClient}

--- a/agot-bg-game-server/src/common/EntireGame.ts
+++ b/agot-bg-game-server/src/common/EntireGame.ts
@@ -221,7 +221,7 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
 
         this.broadcastToClients({
             type: "new-user",
-            user: user.serializeToClient()
+            user: user.serializeToClient(false, user)
         });
 
         return user;
@@ -445,7 +445,7 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
         return {
             id: this.id,
             name: this.name,
-            users: this.users.values.map(u => u.serializeToClient()),
+            users: this.users.values.map(u => u.serializeToClient(admin, user)),
             ownerUserId: this.ownerUserId,
             publicChatRoomId: this.publicChatRoomId,
             gameSettings: this.gameSettings,

--- a/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/IngameGameState.ts
@@ -379,7 +379,7 @@ export default class IngameGameState extends GameState<
                 );
             }
         } else if (message.type == "update-note") {
-            player.note = message.note.substring(0, NOTE_MAX_LENGTH);
+            player.user.note = message.note.substring(0, NOTE_MAX_LENGTH);
         } else if (message.type == "launch-replace-player-by-vassal-vote") {
             const playerToReplace = this.players.get(this.entireGame.users.get(message.player));
 
@@ -1048,7 +1048,7 @@ export default class IngameGameState extends GameState<
 
         return {
             type: "ingame",
-            players: this.players.values.map(p => p.serializeToClient(admin, player)),
+            players: this.players.values.map(p => p.serializeToClient()),
             game: this.game.serializeToClient(admin, player),
             gameLogManager: this.gameLogManager.serializeToClient(),
             votes: this.votes.values.map(v => v.serializeToClient(admin, player)),

--- a/agot-bg-game-server/src/common/ingame-game-state/Player.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/Player.ts
@@ -1,29 +1,25 @@
 import House from "./game-data-structure/House";
 import User from "../../server/User";
 import IngameGameState from "./IngameGameState";
-import { observable } from "mobx";
 
 export default class Player {
     user: User;
     house: House;
-    @observable note = "";
 
     constructor(user: User, house: House) {
         this.user = user;
         this.house = house;
     }
 
-    serializeToClient(admin: boolean, player: Player | null): SerializedPlayer {
+    serializeToClient(): SerializedPlayer {
         return {
             userId: this.user.id,
-            houseId: this.house.id,
-            note: admin ? this.note : player == this ? this.note : ""
+            houseId: this.house.id
         };
     }
 
     static deserializeFromServer(ingame: IngameGameState, data: SerializedPlayer): Player {
         const player = new Player(ingame.entireGame.users.get(data.userId), ingame.game.houses.get(data.houseId));
-        player.note = data.note;
 
         return player;
     }
@@ -32,5 +28,4 @@ export default class Player {
 export interface SerializedPlayer {
     userId: string;
     houseId: string;
-    note: string;
 }

--- a/agot-bg-game-server/src/server/User.ts
+++ b/agot-bg-game-server/src/server/User.ts
@@ -12,6 +12,7 @@ export default class User {
     connectedClients: WebSocket[] = [];
     @observable otherUsersFromSameNetwork: string[] = [];
     @observable connected: boolean;
+    @observable note = "";
 
     constructor(id: string, name: string, game: EntireGame, settings: UserSettings, connected = false, otherUsersFromSameNetwork: string[] = []) {
         this.id = id;
@@ -47,18 +48,21 @@ export default class User {
         }
     }
 
-    serializeToClient(): SerializedUser {
+    serializeToClient(admin: boolean, user: User | null): SerializedUser {
         return {
             id: this.id,
             name: this.name,
             settings: this.settings,
             connected: this.connected,
-            otherUsersFromSameNetwork: this.otherUsersFromSameNetwork
+            otherUsersFromSameNetwork: this.otherUsersFromSameNetwork,
+            note: admin || user == this ? this.note : ""
         }
     }
 
     static deserializeFromServer(game: EntireGame, data: SerializedUser): User {
-        return new User(data.id, data.name, game, data.settings, data.connected, data.otherUsersFromSameNetwork);
+        const user = new User(data.id, data.name, game, data.settings, data.connected, data.otherUsersFromSameNetwork);
+        user.note = data.note;
+        return user;
     }
 }
 
@@ -68,4 +72,5 @@ export interface SerializedUser {
     settings: UserSettings;
     connected: boolean;
     otherUsersFromSameNetwork: string[];
+    note: string;
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -1377,6 +1377,24 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "59",
+        migrate: (serializedGame: any) => {
+            // Init the note for all users
+            const users = serializedGame.users;
+            users.forEach((u: any) => u.note = "");
+            if (serializedGame.childGameState.type == "ingame") {
+                // Move player notes to user
+                const ingame = serializedGame.childGameState;
+                ingame.players.forEach((p: any) => {
+                    const user = users.find((u: any) => u.id == p.userId);
+                    user.note = p.note;
+                });
+            }
+
+            return serializedGame;
+        }
     }
 ];
 


### PR DESCRIPTION
This PR improves 2 things:

1. The notes are moved from player to user, but only players can update their notes. This way replaced players still can access their notes and edit them again, in case they return to the game.
2. The NoteComponent uses a debounce mechanism now, which reduces the sent websocket packets drastically