### PR TITLE
Add replacement needed badge

### DIFF
--- a/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/components/games_table.html
+++ b/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/components/games_table.html
@@ -93,6 +93,15 @@
                                 <i class="fas fa-vote-yea"></i>
                             </span>
                         {% endif %}
+                        {% if game.inactive_players %}
+                            <span class="badge badge-danger"
+                                data-toggle="tooltip"
+                                data-title="<div class='tooltip-title'>Replacement needed for: {{ game.inactive_players }}</div>"
+                                data-html="true"
+                            >
+                                <i class="fas fa-exchange-alt"></i>
+                            </span>
+                        {% endif %}
                     {% endif %}
 
                     {{ game.name }}

--- a/agot-bg-website/agotboardgame_main/views.py
+++ b/agot-bg-website/agotboardgame_main/views.py
@@ -10,6 +10,7 @@ from django.http import HttpResponseRedirect, HttpResponse, HttpResponseNotFound
 from django.shortcuts import render, get_object_or_404
 from django.template.loader import select_template
 from django.views.decorators.http import require_POST
+from django.utils import timezone
 
 from agotboardgame.settings import GROUP_COLORS
 from agotboardgame_main.models import Game, ONGOING, IN_LOBBY, User, CANCELLED, PlayerInGame
@@ -162,7 +163,7 @@ def games(request):
         # Fetch the list of open or ongoing games.
         # Pre-fetch the PlayerInGame entry related to the authenticated player
         # This means that "game.players" will only contain one entry, the one related to the authenticated player.
-        games_query = Game.objects.annotate(players_count=Count('players')).prefetch_related('owner')
+        games_query = Game.objects.annotate(players_count=Count('players')).prefetch_related('owner').prefetch_related('players')
 
         if request.user.is_authenticated:
             games_query = games_query.prefetch_related(Prefetch('players', queryset=PlayerInGame.objects.filter(user=request.user), to_attr="player_in_game"))
@@ -173,12 +174,19 @@ def games(request):
         # It is done in Python
         games = sorted(games, key=lambda game: ([IN_LOBBY, ONGOING].index(game.state), -datetime.timestamp(game.last_active_at)))
 
+        eight_days_past = timezone.now() - timedelta(days=8)
         for game in games:
             # "game.player_in_game" contains a list of one or zero element, depending on whether the authenticated
             # player is in the game.
             # Transform that into a single field that can be None.
+            inactive_players = []
             if request.user.is_authenticated:
                 game.player_in_game = game.player_in_game[0] if len(game.player_in_game) > 0 else None
+                for player_in_game in game.players.all():
+                    if player_in_game.user.last_activity < eight_days_past:
+                        inactive_players.append(player_in_game.user.username)
+                if len(inactive_players) > 0:
+                    game.inactive_players = ", ".join(inactive_players)
             else:
                 game.player_in_game = None
 


### PR DESCRIPTION
This is a first draft of this feature.

Somehow I dont want to spend a new feature for it, and like to add it for all games as it just shows a new icon like vote or new pm. It might happen that this results in unnecessary replacement offers for private games but the players simply will reject the offer or never respond anymore and then I will cancel the game anyways after 2 weeks.

To make it more comfortable I need to change it to use `user.lastActive` instead of `game.lastActive` and check if any of the players is absence for a tbd amount of days. The problem is, it may happen that player A waited tbd - 1 days until his move and player B was not online since then as he was not called yet. Then one day later the game will be marked as replacement needed though he just answered within a day.

So we either have to add a time tracking feature which will count from the point where the player was activated. This has the advantage that we will need that anyways for speed statistics some day.

Or we could increase the amount of days until a player is marked as inactive. Let's say 8 days. The advantage here, all games of that user will be immediately marked as replacement needed. Probably I first go for this approach and will change it to the first approach when we add player speed,