### PR TITLE
Respect that Backdoor Politics can be scored depending on the results of other players

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/ScoreOtherObjectivesComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/ScoreOtherObjectivesComponent.tsx
@@ -10,10 +10,63 @@ import ScoreOtherObjectivesGameState from "../../common/ingame-game-state/action
 
 @observer
 export default class ScoreOtherObjectivesComponent extends Component<GameStateComponentProps<ScoreOtherObjectivesGameState>> {
+    get selectObjectivesState(): SelectObjectiveCardsGameState<ScoreOtherObjectivesGameState> {
+        return this.props.gameState.childGameState;
+    }
+
+    get raiseBackdoorPoliticsWarning(): boolean {
+        if (!this.props.gameClient.authenticatedPlayer) {
+            return false;
+        }
+
+        const controlledHouse = this.props.gameClient.authenticatedPlayer.house;
+
+        if (this.selectObjectivesState.readyHouses.has(controlledHouse)) {
+            return false;
+        }
+
+        const backdoorPolitics = controlledHouse.secretObjectives.find(oc => oc.id == "backdoor-politics");
+
+        if (!backdoorPolitics) {
+            return false;
+        }
+
+        if (this.selectObjectivesState.selectableCardsPerHouse.get(controlledHouse).includes(backdoorPolitics)) {
+            // BP already can be scored.
+            return false;
+        }
+
+        // Now check if it is possible that the server will update the scorable objectives and Backdoor Politics could be scored
+        // after a house chose to score their objective.
+
+        // This can happen when all the houses ahead on IT track have a maximum delta of 3 to the current house on the victory track
+        // (Though it's very unlikely but there are 4 objectives which can grant 4 victory points,
+        // which means by scoring a 4 the houses ahead could overtake the current house on the victory track, thus allowing to score BP)
+        // and if all houses behind on IT track have a higher victory point count than the current house:
+        const game = this.props.gameState.game;
+        const turnOrder = game.getTurnOrder();
+        const ownTurnOrderIndex = turnOrder.findIndex(h => h == controlledHouse);
+        const housesAhead = turnOrder.filter((_h, i) => i < ownTurnOrderIndex);
+        const housesBehind = turnOrder.filter((_h, i) => i > ownTurnOrderIndex);
+
+        const initialVps = this.props.gameState.victoryPointsAtBeginning;
+        return housesAhead.every(h => {
+                if (this.selectObjectivesState.readyHouses.has(h)) {
+                    // House already chose to score, use their actual VP count for comparison
+                    return h.victoryPoints > controlledHouse.victoryPoints;
+                } else {
+                    // House haven't chosen yet. Assume the maximum possible victory points they could score
+                    return Math.min(initialVps.get(h) + 4, game.victoryPointsCountNeededToWin) > controlledHouse.victoryPoints;
+                }
+            }) && housesBehind.every(h => initialVps.get(h) > controlledHouse.victoryPoints);
+    }
+
     render(): ReactNode {
         return <>
             <Col xs={12} className="text-center">
                 Each house may choose to score one Objective card of their choice from their objective hand if the criterion described is fulfilled.
+                {this.raiseBackdoorPoliticsWarning && <><br/><br/><b style={{color: "red"}}>WARNING:</b> You hold <b>Backdoor Politics</b> in your Objectives hand, and you may be able to score it
+                if the other players score before you. You should wait with your decision!</>}
             </Col>
             {renderChildGameState(this.props, [
                 [SelectObjectiveCardsGameState, SelectObjectiveCardsComponent]

--- a/agot-bg-game-server/src/client/game-state-panel/SelectObjectiveCardsComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/SelectObjectiveCardsComponent.tsx
@@ -52,7 +52,7 @@ export default class SelectObjectiveCardsComponent extends Component<GameStateCo
                             </Row>
                         </Col>
                         <Col xs="auto">
-                            <Button variant="success" onClick={() => this.confirm()} disabled={!this.gameState.canBeSkipped && this.selectedObjectiveCards.length != this.gameState.count}>
+                            <Button variant="success" onClick={() => this.confirm()} disabled={(!this.gameState.canBeSkipped && this.selectedObjectiveCards.length != this.gameState.count) || this.selectedObjectiveCards.length > this.gameState.count}>
                                 Confirm
                             </Button>
                         </Col>

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
@@ -91,7 +91,7 @@ export default class PostCombatGameState extends GameState<
             }
         });
 
-        this.combat.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "update-combat-stats",
             stats: this.combat.stats
         })

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/melisandre-ability-game-state/MelisandreAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/melisandre-ability-game-state/MelisandreAbilityGameState.ts
@@ -68,14 +68,14 @@ export default class MelisandreAbilityGameState extends GameState<
         houseCard.state = HouseCardState.AVAILABLE;
         house.powerTokens += -houseCard.combatStrength;
 
-        this.combat.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "change-state-house-card",
             houseId: house.id,
             cardIds: [houseCard.id],
             state: HouseCardState.AVAILABLE
         });
 
-        this.combat.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "change-power-token",
             houseId: house.id,
             powerTokenCount: house.powerTokens

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/patchface-ability-game-state/PatchfaceAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/patchface-ability-game-state/PatchfaceAbilityGameState.ts
@@ -77,7 +77,7 @@ export default class PatchfaceAbilityGameState extends GameState<
             houseCard: houseCard.id
         }, resolvedAutomatically);
 
-        this.combat.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "change-state-house-card",
             houseId: affectedHouse.id,
             cardIds: [houseCard.id],
@@ -93,7 +93,7 @@ export default class PatchfaceAbilityGameState extends GameState<
                 hc.state = HouseCardState.AVAILABLE;
             });
 
-            this.combat.entireGame.broadcastToClients({
+            this.entireGame.broadcastToClients({
                 type: "change-state-house-card",
                 houseId: affectedHouse.id,
                 cardIds: returnedHouseCards.map(hc => hc.id),

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/missandei-ability-game-state/MissandeiAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-winner-determination-game-state/missandei-ability-game-state/MissandeiAbilityGameState.ts
@@ -67,7 +67,7 @@ export default class MissandeiAbilityGameState extends GameState<
 
         houseCard.state = HouseCardState.AVAILABLE;
 
-        this.combat.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "change-state-house-card",
             houseId: house.id,
             cardIds: [houseCard.id],

--- a/agot-bg-game-server/src/common/ingame-game-state/draft-house-cards-game-state/DraftHouseCardsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/draft-house-cards-game-state/DraftHouseCardsGameState.ts
@@ -244,7 +244,7 @@ export default class DraftHouseCardsGameState extends GameState<IngameGameState,
     }
 
     private updateDraftState(): void {
-        this.ingame.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "update-draft-state",
             rowIndex: this.currentRowIndex,
             columnIndex: this.currentColumnIndex,

--- a/agot-bg-game-server/src/common/ingame-game-state/draft-influence-positions-game-state/DraftInfluencePositionsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/draft-influence-positions-game-state/DraftInfluencePositionsGameState.ts
@@ -109,7 +109,7 @@ export default class DraftInfluencePositionsGameState extends GameState<IngameGa
             }
         }
 
-        this.ingame.entireGame.broadcastToClients({
+        this.entireGame.broadcastToClients({
             type: "update-draft-state",
             rowIndex: this.currentRowIndex,
             columnIndex: this.currentColumnIndex,

--- a/agot-bg-game-server/src/common/ingame-game-state/select-objective-cards-game-state/SelectObjectiveCardsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/select-objective-cards-game-state/SelectObjectiveCardsGameState.ts
@@ -20,7 +20,7 @@ interface ParentGameState extends GameState<any, any> {
 }
 
 export default class SelectObjectiveCardsGameState<P extends ParentGameState> extends GameState<P> {
-    selectableCardsPerHouse: BetterMap<House, ObjectiveCard[]>;
+    @observable selectableCardsPerHouse: BetterMap<House, ObjectiveCard[]>;
     count: number;
     canBeSkipped: boolean;
     @observable readyHouses: BetterMap<House, ObjectiveCard[]>;
@@ -110,7 +110,12 @@ export default class SelectObjectiveCardsGameState<P extends ParentGameState> ex
     onServerMessage(message: ServerMessage): void {
         if (message.type == "player-ready") {
             const player = this.parentGameState.ingame.players.get(this.entireGame.users.get(message.userId));
+            // On client-side only set an empty array for the selected objectives to not reveal the choice to other houses
             this.readyHouses.set(player.house, []);
+        } else if (message.type == "update-selectable-objectives") {
+            const house = this.parentGameState.game.houses.get(message.house);
+            const objectives = message.selectableObjectives.map(ocid => objectiveCards.get(ocid));
+            this.selectableCardsPerHouse.set(house, objectives);
         }
     }
 

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -28,7 +28,8 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | VassalRelations | UpdateHouseCardModifier | UpdateHouseCards | UpdateHouseCardsForDrafting | UpdateCombatStats
     | UpdateDraftState | RevealBids | UpdateMaxTurns | PasswordResponse | ReplacedByVassal | UpdateDeletedHouseCards | UpdateOldPlayerHouseCards
     | LoyaltyTokenGained | LoyaltyTokenPlaced | DrangonStrengthTokenRemoved | UpdateLoanCards | UpdateRegionModifiers
-    | UpdateCompletedObjectives | UpdateSecretObjectives | SyncShiftingAmbitionsGameState | HideRevealUserNames | ClearChatRoom;
+    | UpdateCompletedObjectives | UpdateSecretObjectives | SyncShiftingAmbitionsGameState | HideRevealUserNames | ClearChatRoom
+    | UpdateSelectableObjectives;
 
 interface AuthenticationResponse {
     type: "authenticate-response";
@@ -445,4 +446,10 @@ interface HideRevealUserNames {
 interface ClearChatRoom {
     type: "clear-chat-room";
     roomId: string;
+}
+
+interface UpdateSelectableObjectives {
+    type: "update-selectable-objectives";
+    house: string;
+    selectableObjectives: string[];
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -1481,6 +1481,22 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "64",
+        migrate: (serializedGame: any) => {
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+                if (ingame.childGameState.type == "action" && ingame.childGameState.childGameState.type == "score-objectives" &&
+                        ingame.childGameState.childGameState.childGameState.type == "score-other-objectives") {
+                    const scoreOtherObjectives = ingame.childGameState.childGameState.childGameState;
+                    const participatingHouses = scoreOtherObjectives.childGameState.selectableCardsPerHouse.map(([hid, _ocids]: any) => ingame.game.houses.find((sh: any) => sh.id == hid));
+                    scoreOtherObjectives.victoryPointsAtBeginning = participatingHouses.map((sh: any) => [sh.id, sh.victoryPoints]);
+                }
+            }
+
+            return serializedGame;
+        }
     }
 ];
 

--- a/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/components/games_table.html
+++ b/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/components/games_table.html
@@ -98,7 +98,7 @@
                     {% if game.inactive_players %}
                         <span class="badge badge-danger"
                             data-toggle="tooltip"
-                            data-title="<div class='tooltip-title'>Replacement needed for:<br/>{{ game.inactive_players }}</div>"
+                            title="Replacement needed for:<br/>{{ game.inactive_players }}"
                             data-html="true"
                         >
                             <i class="fas fa-exchange-alt"></i>

--- a/agot-bg-website/static/style.css
+++ b/agot-bg-website/static/style.css
@@ -34,3 +34,7 @@ td.fitwidth {
     width: 1px;
     white-space: nowrap;
 }
+
+.tooltip {
+    pointer-events: none;
+}


### PR DESCRIPTION
Many thanks to KevinL who reported this issue and reviewed this stuff!

Fixes #1364 

This PR adds a logic to the code that is hard to understand. I have tried to comment on everything in great detail. The goal of all this is to still be able to score "Secret objectives" simultaneously, instead of doing it in turn order as intended. Of the 28 objectives, there is actually only one that requires turn order: Backdoor Politics. Depending on the decisions of other players, it might be possible for a player sitting far back to score Backdoor Politics. But that's why changing the whole mechanic to turn order, and slow down PBEMs noticeably, didn't make sense to me. Therefore, the game now checks after each scored card whether Backdoor Politics can be scored now. If this happens, which is admittedly quite rare, the player now sees a warning to better wait with his decision:

![BP-Warning](https://user-images.githubusercontent.com/22304202/152797617-22de7ad5-7113-4d49-a9fd-7597636ea124.png)

I manipulated `ChooseInitialObjectivesGameState` so I were able to test a few scenarios, if the warning is raised and the game allows or denies to score Backdoor Politics. In addition I manipulated some OC's like "Stop the Storm" so they give their initially owner VPs to make testing easier.

![image](https://user-images.githubusercontent.com/22304202/152797904-4602cfcf-6664-49d6-828f-6263d5427797.png)


I have tested following scenarios:

This shows the current victory points per IT track position. The bold player had the BP card and I always scored 

0 0 **0** 1
Expected result: BP can be scored. Warning is shown.

0 0 0 **0**
Expected result: BP can be scored. Warning is shown.

0 0 **0** 0
Expected result: BP can't be scored. Warning is not raised.

0 **0** 0 1
Expected result: BP can't be scored. Warning is not raised.

1 **0** 1 1
Expected result: BP can be scored. Warning is not raised.


All tests passed.
