### PR TITLE
Some website improvements

### DIFF
--- a/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/games.html
+++ b/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/games.html
@@ -120,7 +120,12 @@ Games -
         <div class="col-lg-11 mb-4">
             <div class="card">
                 <div class="card-body">
-                    <h4 class="card-title">Games with players who have not logged in for 8 days</h4>
+                    <h4 class="card-title"
+                        data-toggle="tooltip"
+                        title="These are games where the last move was more than 2 days ago and the player being waited on has not logged in for 8 days."
+                    >
+                        Games waiting for inactive players
+                    </h4>
                     <div style="max-height: 300px; overflow-y: auto">
                         {% games_table replacement_needed_games user perms %}
                     </div>

--- a/agot-bg-website/api/serializers.py
+++ b/agot-bg-website/api/serializers.py
@@ -5,6 +5,8 @@ from rest_framework.serializers import ModelSerializer, BooleanField
 from agotboardgame_main.models import User, Game, PlayerInGame, PbemResponseTime
 from chat.models import Room, UserInRoom
 
+from django.db import transaction
+
 
 class PbemResponseTimeSerializer(ModelSerializer):
     class Meta:
@@ -36,6 +38,7 @@ class GameSerializer(ModelSerializer):
         model = Game
         fields = ['id', 'name', 'owner', 'serialized_game', 'view_of_game', 'state', 'version', 'players', 'update_last_active']
 
+    @transaction.atomic
     def update(self, instance, validated_data):
         instance.version = validated_data.pop('version', instance.version)
         instance.serialized_game = validated_data.pop('serialized_game', instance.serialized_game)


### PR DESCRIPTION
The goal of this PR is to avoid the bug where sometimes the Games page shows more players in a game than maxPlayerCount by executing the PlayersInGame update in a transaction.

The second goal is to improve the replacement needed badge and only show it when the game is stalled for 2 days and we are really waiting for the inactive player. This shall avoid replacement offers for players who have not logged in because they were not activated. In return, games that search for replacement will no longer be displayed in the inactive games list.