### PR TITLE
Preemptive Raid Night's Watch Victory does not affect the current wildling token position

### DIFF
--- a/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/wildlings-attack-component/WildlingsAttackComponent.tsx
@@ -75,11 +75,12 @@ export default class WildlingsAttackComponent extends Component<GameStateCompone
                 <ListGroupItem className="px-2">
                     <Row>
                         {this.props.gameState.childGameState instanceof BiddingGameState ? (
-                            <Col xs={12}>
-                                <b>All houses</b>{this.props.gameState.excludedHouses.length >0 &&
+                            <Col xs={12} className="text-center mb-3">
+                                <b>All player houses</b>{this.props.gameState.excludedHouses.length > 0 &&
                                 (<> except {joinReactNodes(this.props.gameState.excludedHouses.map(h =>
-                                <b key={h.id}>{h.name}</b>), ", ")}</>)} bid Power tokens to overcome the
-                                Wildlings which are attacking with a strength of <b>{this.props.gameState.game.wildlingStrength}</b>!
+                                <b key={h.id}>{h.name}</b>), ", ")}</>)} bid Power tokens to overcome the Wildlings<br/>
+                                which are attacking with a strength
+                                of <h3 className="mx-2" style={{display: "inline", verticalAlign: "-6px"}}>{this.props.gameState.wildlingStrength}</h3>!
                             </Col>
                         ) : results ?
                             <Col xs={12} className="no-space-around">

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/wildling-card/PreemptiveRaidWildlingCardType.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/wildling-card/PreemptiveRaidWildlingCardType.ts
@@ -9,10 +9,10 @@ export default class PreemptiveRaidWildlingCardType extends WildlingCardType {
     executeNightsWatchWon(wildlingsAttack: WildlingsAttackGameState): void {
         const wildlingStrength = 6;
 
-        wildlingsAttack.game.wildlingStrength = wildlingStrength;
+        wildlingsAttack.game.wildlingStrength = 0;
         wildlingsAttack.entireGame.broadcastToClients({
             type: "change-wildling-strength",
-            wildlingStrength: wildlingStrength
+            wildlingStrength: 0
         });
 
         wildlingsAttack.ingame.log({

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/wildlings-attack-game-state/WildlingsAttackGameState.ts
@@ -44,7 +44,7 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
     // This field is null before the bidding phase is over,
     // as the wildling card will be drawn after the bidding phase is over.
     wildlingCard: WildlingCard | null;
-    wildlingStrength: number;
+    @observable wildlingStrength: number;
     _highestBidder: House | null;
     _lowestBidder: House | null;
     @observable biddingResults: [number, House[]][] | null;
@@ -54,7 +54,7 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
     }
 
     get excludedHouses(): House[] {
-        return _.difference(this.game.houses.values, this.participatingHouses);
+        return _.difference(this.game.houses.values, this.participatingHouses).filter(h => !this.ingame.isVassalHouse(h));
     }
 
     get totalBid(): number {
@@ -166,7 +166,7 @@ export default class WildlingsAttackGameState extends GameState<WesterosGameStat
 
         this.westerosGameState.ingame.log({
             type: "wildling-bidding",
-            wildlingStrength: this.westerosGameState.game.wildlingStrength,
+            wildlingStrength: this.wildlingStrength,
             results: this.biddingResults.map(([bid, houses]) => [bid, houses.map(h => h.id)]),
             nightsWatchVictory: this.nightsWatchWon
         });


### PR DESCRIPTION
Closes #1578 

Although it hasn't been approved by Jason yet, I'm thinking more and more that the card would say "and move the token to position 6" if it's intended. Since the rules don't explicitly say that wildling attack strength is always reflected by the wildling track, we should change that until Jason proves otherwise.