### PR TITLE
Fix Walder Frey is not always updating battle dialog

### DIFF
--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/CombatGameState.ts
@@ -552,7 +552,12 @@ export default class CombatGameState extends GameState<
             this.specialHouseCardModifier = { houseCard: this.game.getHouseCardById(message.houseCardId), combatStrength: message.combatStrength };
         } else if (message.type == "update-combat-stats") {
             this.stats = message.stats;
-        } else {
+        } else if (message.type == "support-declared") {
+            const house = this.game.houses.get(message.houseId);
+            const supportedHouse = message.supportedHouseId ? this.game.houses.get(message.supportedHouseId) : null;
+            this.supporters.set(house, supportedHouse);
+        }
+        else {
             this.childGameState.onServerMessage(message);
         }
     }

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/declare-support-game-state/DeclareSupportGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/declare-support-game-state/DeclareSupportGameState.ts
@@ -46,13 +46,7 @@ export default class DeclareSupportGameState extends GameState<CombatGameState> 
         }
     }
 
-    onServerMessage(message: ServerMessage): void {
-        if (message.type == "support-declared") {
-            const house = this.game.houses.get(message.houseId);
-            const supportedHouse = message.supportedHouseId ? this.game.houses.get(message.supportedHouseId) : null;
-
-            this.combatGameState.supporters.set(house, supportedHouse);
-        }
+    onServerMessage(_message: ServerMessage): void {
     }
 
     getWaitedUsers(): User[] {

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/WalderFreyHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/WalderFreyHouseCardAbility.ts
@@ -11,6 +11,11 @@ export default class WalderFreyHouseCardAbility extends HouseCardAbility {
             const supporting = combat.supporters.get(supporter);
             if (supporter != enemy && supporting == enemy) {
                 combat.supporters.set(supporter, house);
+                combat.entireGame.broadcastToClients({
+                    type: "support-declared",
+                    houseId: supporter.id,
+                    supportedHouseId: house.id
+                });
             }
         });
 

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -1883,7 +1883,7 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
         migrate: (serializedGame: any) => {
             if (serializedGame.childGameState.type == "ingame" && serializedGame.gameSettings.setupId == "a-dance-with-mother-of-dragons") {
                 const ingame = serializedGame.childGameState;
-                
+
                 if (ingame.childGameState.type == "westeros") {
                     const westeros = ingame.childGameState;
 


### PR DESCRIPTION
This PR fixes missing UI update on client side if Walder Frey forces a VSB decision:

![image](https://user-images.githubusercontent.com/22304202/184835774-688d741d-e8f4-4adc-af94-4e6e48b26fc0.png)

Server side everything was and is fine and therefore a client reload solved the UI but it was confusing and therefore this PR updates UI immediately now:

![image](https://user-images.githubusercontent.com/22304202/184836696-9d7efc1e-4097-4e75-a115-6387ac8fdf18.png)
