### PR TITLE
Fix chat issues and force players to commit orders again after vassal replacement

### DIFF
--- a/agot-bg-game-server/src/client/chat-client/ChatClient.ts
+++ b/agot-bg-game-server/src/client/chat-client/ChatClient.ts
@@ -78,7 +78,7 @@ export default class ChatClient {
             channel.connected = true;
             // Ask for the first 15 messages with a delay of 100ms to decrease pressure
             window.setTimeout(() => {
-                channel.websocket.send(JSON.stringify({type: 'chat_retrieve', count: 15, first_message_id: null }))
+                channel.websocket.send(JSON.stringify({type: 'chat_retrieve', count: 15, first_message_id: null, faceless: this.gameClient.entireGame?.gameSettings.faceless ?? false }))
             }, 100);
         };
         websocket.onclose = () => channel.connected = false;
@@ -118,7 +118,7 @@ export default class ChatClient {
             return;
         }
         const fromHouse = this.gameClient.entireGame.ingameGameState?.players.tryGet(authenticatedUser, null)?.house.name ?? "Unknown";
-        channel.websocket.send(JSON.stringify({type: 'chat_message', text, gameId: this.gameClient.entireGame.id, fromHouse: fromHouse }));
+        channel.websocket.send(JSON.stringify({type: 'chat_message', text, gameId: this.gameClient.entireGame.id, fromHouse: fromHouse, faceless: this.gameClient.entireGame.gameSettings.faceless }));
     }
 
     onMessage(channel: Channel, message: ChatServerMessage): void {
@@ -166,7 +166,7 @@ export default class ChatClient {
             return false;
         }
 
-        channel.websocket.send(JSON.stringify({type: 'chat_retrieve', count: 50, first_message_id: channel.messages[0].id }));
+        channel.websocket.send(JSON.stringify({type: 'chat_retrieve', count: 50, first_message_id: channel.messages[0].id, faceless: this.gameClient.entireGame.gameSettings.faceless }));
         return true;
     }
 

--- a/agot-bg-game-server/src/common/EntireGame.ts
+++ b/agot-bg-game-server/src/common/EntireGame.ts
@@ -321,6 +321,8 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
         });
         this.users.set(user.id, user);
 
+        this.saveGame(false);
+
         this.broadcastToClients({
             type: "new-user",
             user: user.serializeToClient(false, user, this.gameSettings.faceless)

--- a/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/components/games_chat.html
+++ b/agot-bg-website/agotboardgame_main/templates/agotboardgame_main/components/games_chat.html
@@ -31,7 +31,7 @@
             chatWebsocket = new WebSocket((url.protocol == 'http:' ? 'ws:' : 'wss:') + '//' + url.host + '/ws/chat/room/' + publicRoomId);
             chatWebsocket.onopen = () => {
                 this.setState({state: 1});
-                chatWebsocket.send(JSON.stringify({type: 'chat_retrieve', count: 20, first_message_id: null}));
+                chatWebsocket.send(JSON.stringify({type: 'chat_retrieve', count: 20, first_message_id: null, faceless: false}));
             };
             chatWebsocket.onmessage = m => {
                 const data = JSON.parse(m.data);
@@ -65,7 +65,7 @@
 
         sendMessage(e) {
             e.preventDefault();
-            const data = {type: 'chat_message', text: this.state.input};
+            const data = {type: 'chat_message', text: this.state.input, faceless: false};
             chatWebsocket.send(JSON.stringify(data));
             this.setState({input: ''});
         }
@@ -77,7 +77,7 @@
                 return;
             }
 
-            const data = {type: 'chat_retrieve', count: 50, first_message_id: this.state.messages[0].id};
+            const data = {type: 'chat_retrieve', count: 50, first_message_id: this.state.messages[0].id, faceless: false};
             chatWebsocket.send(JSON.stringify(data));
         }
 


### PR DESCRIPTION
Closes #1755 
Closes #1748 

Additionally this PR saves the game after a user has been added to the game to make sure every chat message can be parsed. As we unload games, a user may hop into a game, write to the public chat and then the game can be unloaded and the user id will never be saved to the database. This makes messages unreadable from those users. Therefore we save the game directly now after a user has been added.