### PR TITLE
Increase game components' maxHeight to utilize all of the available v…

### DIFF
--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -243,7 +243,7 @@ export default class IngameComponent extends Component<IngameComponentProps> {
         const tracks = this.tracks;
 
         return <>
-                <Row className="justify-content-center" style={{maxHeight: this.mapScrollbarEnabled ? "95vh" : "none"}}>
+                <Row className="justify-content-center" style={{maxHeight: this.mapScrollbarEnabled ? "100vh" : "none"}}>
                     <Col xs={{order: columnOrders.gameStateColumn}} className={this.columnSwapAnimationClassName}
                         style={{maxHeight: this.mapScrollbarEnabled ? "100%" : "none", minWidth: col1MinWidth, maxWidth: draftHouseCards ? "1200px" : "800px"}}
                     >

--- a/agot-bg-game-server/src/client/ReplayComponent.tsx
+++ b/agot-bg-game-server/src/client/ReplayComponent.tsx
@@ -143,7 +143,7 @@ export default class ReplayComponent extends Component<ReplayComponentProps> {
 
         const col1MinWidth = this.gameSettings.playerCount >= 8 ? "485px" : "470px";
 
-        return <Row className="justify-content-center" style={{maxHeight: this.mapScrollbarEnabled ? "95vh" : "none"}}>
+        return <Row className="justify-content-center" style={{maxHeight: this.mapScrollbarEnabled ? "100vh" : "none"}}>
             <Col xs={{order: columnOrders.gameStateColumn}} className={this.columnSwapAnimationClassName}
                 style={{maxHeight: this.mapScrollbarEnabled ? "100%" : "none", minWidth: col1MinWidth, maxWidth: "800px"}}
             >


### PR DESCRIPTION
#1833

Increase game components' maxHeight to utilize all of the available vertical space:

![image](https://github.com/Longwelwind/swords-and-ravens/assets/44836615/b9f14b63-2d62-4344-ba52-575f374a43e5)

This is useful since the map is usually scrollable on most screens and this will reduce this a little.